### PR TITLE
sha256 dummy: use embedded_cal::NoHashAlgorithms

### DIFF
--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -13,21 +13,6 @@ pub struct DummySha256;
 
 impl embedded_cal::Cal for DummySha256 {}
 
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum NoFullAlgorithms {}
-
-impl embedded_cal::HashAlgorithm for NoFullAlgorithms {
-    fn len(&self) -> usize {
-        match *self {}
-    }
-}
-
-impl AsRef<[u8]> for NoFullAlgorithms {
-    fn as_ref(&self) -> &[u8] {
-        match *self {}
-    }
-}
-
 const k: [u32; 64] = [
     0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
     0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
@@ -40,9 +25,9 @@ const k: [u32; 64] = [
 ];
 
 impl embedded_cal::HashProvider for DummySha256 {
-    type Algorithm = NoFullAlgorithms;
-    type HashState = NoFullAlgorithms;
-    type HashResult = NoFullAlgorithms;
+    type Algorithm = embedded_cal::NoHashAlgorithms;
+    type HashState = embedded_cal::NoHashAlgorithms;
+    type HashResult = embedded_cal::NoHashAlgorithms;
 
     fn init(&mut self, algorithm: Self::Algorithm) -> Self::HashState {
         match algorithm {}


### PR DESCRIPTION
This was missed in https://github.com/lake-rs/embedded-cal/pull/22 when that type was moved out from other users that copied the dummy's implementation.