### PR TITLE
chore: add from_ni_name to embedded-cal-software

### DIFF
--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -214,6 +214,14 @@ impl<EC: ExtenderConfig> embedded_cal::HashAlgorithm for HashAlgorithm<EC> {
             _ => None,
         }
     }
+
+    #[inline]
+    fn from_ni_name(name: &str) -> Option<Self> {
+        match name {
+            "sha-256" => Self::from_cose_number(-16),
+            _ => None,
+        }
+    }
 }
 
 pub enum HashState<EC: ExtenderConfig> {


### PR DESCRIPTION
Trying to use `embedded-cal` I discovered that `from_ni_name` is not implemented.