### PR TITLE
nRF54 typed descriptor chains

### DIFF
--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -121,6 +121,15 @@ impl<Direction, const N: usize> DescriptorChain<Direction, N> {
         self.update_links();
         &self.descs[0] as *const Descriptor as u32
     }
+
+    /// Calls `f` with the address of the first descriptor, holding a `&mut self`
+    /// borrow for the duration of the call.
+    ///
+    /// This guarantees that the descriptor chain remains live and pinned in memory
+    /// while `f` is executing, so the pointer passed to hardware stays valid.
+    pub(crate) fn with_first_pointer(&mut self, f: impl FnOnce(u32) -> ()) {
+        f(self.first())
+    }
 }
 
 impl<const N: usize> DescriptorChain<Input, N> {

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -66,13 +66,13 @@ pub(crate) struct Output;
 ///
 /// `Direction` is either [`Input`] or [`Output`], distinguishing read-from-memory and
 /// write-to-memory chains at the type level.
-pub(crate) struct DescriptorChain<Direction, const N: usize> {
+pub(crate) struct DescriptorChain<'mem, Direction, const N: usize> {
     descs: [Descriptor; N],
     count: usize,
-    _dir: core::marker::PhantomData<Direction>,
+    _dir: core::marker::PhantomData<&'mem Direction>,
 }
 
-impl<Direction, const N: usize> DescriptorChain<Direction, N> {
+impl<'mem, Direction, const N: usize> DescriptorChain<'mem, Direction, N> {
     /// Creates an empty `DescriptorChain`.
     ///
     /// The chain is initialized with all descriptors zero-filled and contains
@@ -127,12 +127,22 @@ impl<Direction, const N: usize> DescriptorChain<Direction, N> {
     ///
     /// This guarantees that the descriptor chain remains live and pinned in memory
     /// while `f` is executing, so the pointer passed to hardware stays valid.
+    ///
+    /// # Safety
+    ///
+    /// This function is not unsafe to use on its own, but typically used to call
+    /// `dma.fetchaddrlsb().write_value(…)` or `dma.fpushaddrlsb().write_value(…)` the argument,
+    /// which is an unsafe operation.
+    ///
+    /// To make that operation safe, `f` must wait until END or ERROR is observed on the relevant
+    /// EasyDMA. It must not return **or panic** between starting the DMA operation and observing
+    /// its completion.
     pub(crate) fn with_first_pointer(&mut self, f: impl FnOnce(u32) -> ()) {
         f(self.first())
     }
 }
 
-impl<const N: usize> DescriptorChain<Input, N> {
+impl<'mem, const N: usize> DescriptorChain<'mem, Input, N> {
     /// Appends an input (read) buffer to the chain.
     ///
     /// The DMA engine will read from `data` during the transfer.
@@ -140,9 +150,7 @@ impl<const N: usize> DescriptorChain<Input, N> {
     /// # Safety / Correctness requirements
     ///
     /// - `data` must be DMA-accessible memory.
-    /// - The chain must not be mutated after being handed to the EasyDMA
-    ///   hardware until the END or ERROR event is observed.
-    pub(crate) fn push(&mut self, data: &[u8], dmatag: u32) {
+    pub(crate) fn push(&mut self, data: &'mem [u8], dmatag: u32) {
         self.push_descriptor(Descriptor::new(
             data.as_ptr() as *mut u8,
             sz(data.len()),
@@ -151,7 +159,7 @@ impl<const N: usize> DescriptorChain<Input, N> {
     }
 }
 
-impl<const N: usize> DescriptorChain<Output, N> {
+impl<'mem, const N: usize> DescriptorChain<'mem, Output, N> {
     /// Appends an output (write) buffer to the chain.
     ///
     /// The DMA engine will write into `data` during the transfer.
@@ -159,9 +167,7 @@ impl<const N: usize> DescriptorChain<Output, N> {
     /// # Safety / Correctness requirements
     ///
     /// - `data` must be DMA-accessible memory.
-    /// - The chain must not be mutated after being handed to the EasyDMA
-    ///   hardware until the END or ERROR event is observed.
-    pub(crate) fn push(&mut self, data: &mut [u8], dmatag: u32) {
+    pub(crate) fn push(&mut self, data: &'mem mut [u8], dmatag: u32) {
         self.push_descriptor(Descriptor::new(data.as_mut_ptr(), sz(data.len()), dmatag));
     }
 }

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -69,7 +69,7 @@ pub(crate) struct Output;
 pub(crate) struct DescriptorChain<'mem, Direction, const N: usize> {
     descs: [Descriptor; N],
     count: usize,
-    _dir: core::marker::PhantomData<&'mem Direction>,
+    _dir: core::marker::PhantomData<*mut &'mem Direction>,
 }
 
 impl<'mem, Direction, const N: usize> DescriptorChain<'mem, Direction, N> {

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -60,8 +60,9 @@ pub(crate) struct Output;
 /// This type owns a small array of `Descriptor`s and tracks how many entries
 /// are currently in use.
 ///
-/// DescriptorChain also make sure they are linked like a linked-list
-/// and the last Descriptor.next is always LAST_DESC_PTR
+/// Descriptors are linked into a list (with the last terminated by [`LAST_DESC_PTR`])
+/// lazily, just before use, in [`first`](DescriptorChain::first). This avoids the
+/// struct being self-referential at rest, which would make it unsafe to move after pushing.
 ///
 /// `Direction` is either [`Input`] or [`Output`], distinguishing read-from-memory and
 /// write-to-memory chains at the type level.
@@ -95,21 +96,30 @@ impl<Direction, const N: usize> DescriptorChain<Direction, N> {
         let idx = self.count;
         self.descs[idx] = desc;
         self.count += 1;
+    }
 
-        // update links
-        if idx > 0 {
-            self.descs[idx - 1].next = &mut self.descs[idx];
+    /// Sets the `next` pointer of each descriptor to point to the following one,
+    /// and terminates the chain with [`LAST_DESC_PTR`].
+    ///
+    /// Links are set here rather than at push time to avoid the struct being
+    /// self-referential at rest (which would make it unsafe to move after pushing).
+    fn update_links(&mut self) {
+        for i in 1..self.count {
+            self.descs[i - 1].next = &mut self.descs[i];
         }
-
-        self.descs[idx].next = LAST_DESC_PTR;
+        if self.count > 0 {
+            self.descs[self.count - 1].next = LAST_DESC_PTR;
+        }
     }
 
     /// Returns an address to the first descriptor in the chain.
     ///
     /// This pointer is intended to be written to the EasyDMA input/output pointer
     /// register to start a scatter-gather transfer.
-    pub(crate) fn first(&mut self) -> u32 {
-        &mut self.descs[0] as *mut Descriptor as u32
+    fn first(&mut self) -> u32 {
+        assert!(self.count > 0);
+        self.update_links();
+        &self.descs[0] as *const Descriptor as u32
     }
 }
 

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -50,6 +50,11 @@ impl Descriptor {
     }
 }
 
+/// Marker type for a descriptor chain that feeds data into the DMA engine (reads from memory).
+pub(crate) struct Input;
+/// Marker type for a descriptor chain that receives data from the DMA engine (writes to memory).
+pub(crate) struct Output;
+
 /// Fixed-capacity scatter-gather descriptor chain.
 ///
 /// This type owns a small array of `Descriptor`s and tracks how many entries
@@ -57,12 +62,16 @@ impl Descriptor {
 ///
 /// DescriptorChain also make sure they are linked like a linked-list
 /// and the last Descriptor.next is always LAST_DESC_PTR
-pub(crate) struct DescriptorChain<const N: usize> {
+///
+/// `Direction` is either [`Input`] or [`Output`], distinguishing read-from-memory and
+/// write-to-memory chains at the type level.
+pub(crate) struct DescriptorChain<Direction, const N: usize> {
     descs: [Descriptor; N],
     count: usize,
+    _dir: core::marker::PhantomData<Direction>,
 }
 
-impl<const N: usize> DescriptorChain<N> {
+impl<Direction, const N: usize> DescriptorChain<Direction, N> {
     /// Creates an empty `DescriptorChain`.
     ///
     /// The chain is initialized with all descriptors zero-filled and contains
@@ -71,32 +80,17 @@ impl<const N: usize> DescriptorChain<N> {
         Self {
             descs: [Descriptor::empty(); N],
             count: 0,
+            _dir: core::marker::PhantomData,
         }
     }
 
-    /// Appends a descriptor to the end of the chain.
-    ///
-    /// This method:
-    /// - Stores `desc` in the next free slot.
-    /// - Updates the `next` pointer of the previous descriptor to point to the
-    ///   newly added one.
-    /// - Ensures the newly added descriptor’s `next` pointer is set to
-    ///   `LAST_DESC_PTR`, marking it as the terminal job entry.
+    /// Links a new [`Descriptor`] into the chain.
     ///
     /// # Panics
     ///
     /// Panics if the chain is already at full capacity.
-    ///
-    /// # Safety / Correctness requirements
-    ///
-    /// - The descriptor and all previously pushed descriptors must remain
-    ///   valid and unmodified while a DMA transfer is in progress.
-    /// - All descriptors in the chain must describe DMA-accessible memory.
-    /// - The chain must not be mutated after being handed to the EasyDMA
-    ///   hardware until the END or ERROR event is observed.
-    pub(crate) fn push(&mut self, addr: *mut u8, sz: u32, dmatag: u32) {
+    fn push_descriptor(&mut self, desc: Descriptor) {
         assert!(self.count < N);
-        let desc = Descriptor::new(addr, sz, dmatag);
 
         let idx = self.count;
         self.descs[idx] = desc;
@@ -104,8 +98,7 @@ impl<const N: usize> DescriptorChain<N> {
 
         // update links
         if idx > 0 {
-            let prev = idx - 1;
-            self.descs[prev].next = &mut self.descs[idx];
+            self.descs[idx - 1].next = &mut self.descs[idx];
         }
 
         self.descs[idx].next = LAST_DESC_PTR;
@@ -120,9 +113,43 @@ impl<const N: usize> DescriptorChain<N> {
     }
 }
 
+impl<const N: usize> DescriptorChain<Input, N> {
+    /// Appends an input (read) buffer to the chain.
+    ///
+    /// The DMA engine will read from `data` during the transfer.
+    ///
+    /// # Safety / Correctness requirements
+    ///
+    /// - `data` must be DMA-accessible memory.
+    /// - The chain must not be mutated after being handed to the EasyDMA
+    ///   hardware until the END or ERROR event is observed.
+    pub(crate) fn push(&mut self, data: &[u8], dmatag: u32) {
+        self.push_descriptor(Descriptor::new(
+            data.as_ptr() as *mut u8,
+            sz(data.len()),
+            dmatag,
+        ));
+    }
+}
+
+impl<const N: usize> DescriptorChain<Output, N> {
+    /// Appends an output (write) buffer to the chain.
+    ///
+    /// The DMA engine will write into `data` during the transfer.
+    ///
+    /// # Safety / Correctness requirements
+    ///
+    /// - `data` must be DMA-accessible memory.
+    /// - The chain must not be mutated after being handed to the EasyDMA
+    ///   hardware until the END or ERROR event is observed.
+    pub(crate) fn push(&mut self, data: &mut [u8], dmatag: u32) {
+        self.push_descriptor(Descriptor::new(data.as_mut_ptr(), sz(data.len()), dmatag));
+    }
+}
+
 /// Asserts that size is a multiple of 4, and ORs in the DMA_REALIGN constant.
 #[inline]
-pub(crate) const fn sz(n: usize) -> u32 {
+const fn sz(n: usize) -> u32 {
     const DMA_REALIGN: usize = 0x2000_0000;
     debug_assert!(
         n % 4 == 0,

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -148,29 +148,33 @@ impl Nrf54l15Cal {
         input_descriptors: &mut DescriptorChain<Input, N>,
         output_descriptors: &mut DescriptorChain<Output, N>,
     ) -> () {
-        let dma = self.cracen_core.cryptmstrdma();
-        // Configure DMA source
-        dma.fetchaddrlsb().write_value(input_descriptors.first());
+        input_descriptors.with_first_pointer(|input_ptr| {
+            output_descriptors.with_first_pointer(|output_ptr| {
+                let dma = self.cracen_core.cryptmstrdma();
+                // Configure DMA source
+                dma.fetchaddrlsb().write_value(input_ptr);
 
-        // Configure DMA sink
-        dma.pushaddrlsb().write_value(output_descriptors.first());
+                // Configure DMA sink
+                dma.pushaddrlsb().write_value(output_ptr);
 
-        dma.config().write(|w| {
-            w.set_fetchctrlindirect(true);
-            w.set_pushctrlindirect(true);
-            w.set_fetchstop(false);
-            w.set_pushstop(false);
-            w.set_softrst(false)
+                dma.config().write(|w| {
+                    w.set_fetchctrlindirect(true);
+                    w.set_pushctrlindirect(true);
+                    w.set_fetchstop(false);
+                    w.set_pushstop(false);
+                    w.set_softrst(false)
+                });
+
+                // Start DMA
+                dma.start().write(|w| {
+                    w.set_startfetch(true);
+                    w.set_startpush(true)
+                });
+
+                // Wait
+                while dma.status().read().fetchbusy() {}
+                while dma.status().read().pushbusy() {}
+            });
         });
-
-        // Start DMA
-        dma.start().write(|w| {
-            w.set_startfetch(true);
-            w.set_startpush(true)
-        });
-
-        // Wait
-        while dma.status().read().fetchbusy() {}
-        while dma.status().read().pushbusy() {}
     }
 }

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -150,12 +150,10 @@ impl Nrf54l15Cal {
     ) -> () {
         let dma = self.cracen_core.cryptmstrdma();
         // Configure DMA source
-        dma.fetchaddrlsb()
-            .write_value(input_descriptors.first() as u32);
+        dma.fetchaddrlsb().write_value(input_descriptors.first());
 
         // Configure DMA sink
-        dma.pushaddrlsb()
-            .write_value(output_descriptors.first() as u32);
+        dma.pushaddrlsb().write_value(output_descriptors.first());
 
         dma.config().write(|w| {
             w.set_fetchctrlindirect(true);

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -1,13 +1,10 @@
 #![no_std]
 mod descriptor;
 
-use descriptor::DescriptorChain;
+use descriptor::{DescriptorChain, Input, Output};
 use nrf_pac::{cracen, cracencore};
 
-use crate::descriptor::sz;
-
 const MAX_DESCRIPTOR_CHAIN_LEN: usize = 4;
-const INTERNAL_STATE_LEN: usize = 32;
 
 pub struct Nrf54l15Cal {
     // FIXME: No need to enable and take ownership of everything
@@ -115,24 +112,20 @@ impl embedded_cal::plumbing::hash::Sha2Short for Nrf54l15Cal {
 
         let header: [u8; 4] = [0x08, 0x00, 0x00, 0x00];
 
-        let state_len = INTERNAL_STATE_LEN;
+        let mut output_descriptors: DescriptorChain<Output, MAX_DESCRIPTOR_CHAIN_LEN> =
+            DescriptorChain::new();
+        output_descriptors.push(&mut new_state, 32);
 
-        let mut output_descriptors = DescriptorChain::<MAX_DESCRIPTOR_CHAIN_LEN>::new();
-        output_descriptors.push(new_state.as_mut_ptr(), sz(state_len), 32);
+        let mut input_descriptors: DescriptorChain<Input, MAX_DESCRIPTOR_CHAIN_LEN> =
+            DescriptorChain::new();
 
-        let mut input_descriptors = DescriptorChain::<MAX_DESCRIPTOR_CHAIN_LEN>::new();
-
-        input_descriptors.push(header.as_ptr() as *mut u8, sz(4), 19);
+        input_descriptors.push(&header, 19);
 
         if let Some(state) = &instance.state {
-            input_descriptors.push(state.as_ptr() as *mut u8, sz(state_len), 99);
+            input_descriptors.push(state, 99);
         }
 
-        input_descriptors.push(
-            data.as_ptr() as *mut u8,
-            0x2000_0000 | data.len() as u32,
-            35,
-        );
+        input_descriptors.push(data, 35);
 
         self.execute_cryptomaster_dma(&mut input_descriptors, &mut output_descriptors);
 
@@ -152,8 +145,8 @@ impl embedded_cal::plumbing::hash::Sha2Short for Nrf54l15Cal {
 impl Nrf54l15Cal {
     fn execute_cryptomaster_dma<const N: usize>(
         &mut self,
-        input_descriptors: &mut DescriptorChain<N>,
-        output_descriptors: &mut DescriptorChain<N>,
+        input_descriptors: &mut DescriptorChain<Input, N>,
+        output_descriptors: &mut DescriptorChain<Output, N>,
     ) -> () {
         let dma = self.cracen_core.cryptmstrdma();
         // Configure DMA source


### PR DESCRIPTION
enhancements for the nRF54 code. https://github.com/lake-rs/embedded-cal/issues/26

This PR is divided in 3 commits:
* First one, create diff types for Input and Output in `DescriptorChain`s, it should make it type safer for creating and using this API
* Updates all the `.next` field just before calling `first()`. It should make it safer to protect against moves
* Add `with_first_pointer` to hold the `DescriptorChain` pinned in memory while is being used.

  