### PR TITLE
feat: Include rand_core::TryCryptoRng in traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ name = "embedded-cal"
 version = "0.1.0"
 dependencies = [
  "hax-lib",
+ "rand_core",
 ]
 
 [[package]]
@@ -212,6 +213,7 @@ dependencies = [
  "embedded-cal-software",
  "nrf-pac",
  "panic-probe",
+ "rand_core",
  "testvectors",
 ]
 
@@ -230,6 +232,7 @@ name = "embedded-cal-software"
 version = "0.1.0"
 dependencies = [
  "embedded-cal",
+ "rand_core",
  "testvectors",
 ]
 
@@ -245,6 +248,7 @@ dependencies = [
  "embedded-cal",
  "embedded-cal-software",
  "panic-probe",
+ "rand_core",
  "stm32-metapac",
  "testvectors",
 ]
@@ -469,6 +473,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ version = "0.1.0"
 
 [workspace.dependencies]
 hax-lib.git = "https://github.com/hacspec/hax"
+rand_core = { version = "0.10", default-features = false }

--- a/embedded-cal-nrf54l15/Cargo.toml
+++ b/embedded-cal-nrf54l15/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 [dependencies]
 embedded-cal.path = "../embedded-cal"
 nrf-pac = { version = "0.2.0", features = ["nrf54l15-app", "rt"] }
+rand_core.workspace = true
 
 [dev-dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 mod descriptor;
+mod try_rng;
 
 use descriptor::{DescriptorChain, Input, Output};
 use nrf_pac::{cracen, cracencore};
@@ -24,6 +25,16 @@ impl Nrf54l15Cal {
             w.set_pkeikg(true)
         });
 
+        // Enable the NDRNG; it stays on until Drop.
+        cracen_core
+            .rngcontrol()
+            .control()
+            .modify(|w| w.set_enable(true));
+
+        // Discard the first FIFO word produced after the startup conditioning period
+        while cracen_core.rngcontrol().fifolevel().read() == 0 {}
+        let _ = cracen_core.rngcontrol().fifo(0).read();
+
         Self {
             cracen,
             cracen_core,
@@ -33,6 +44,12 @@ impl Nrf54l15Cal {
 
 impl Drop for Nrf54l15Cal {
     fn drop(&mut self) {
+        // Disable NDRNG
+        self.cracen_core
+            .rngcontrol()
+            .control()
+            .modify(|w| w.set_enable(false));
+
         // Disable cryptomaster on drop
         self.cracen.enable().write(|w| {
             w.set_cryptomaster(false);

--- a/embedded-cal-nrf54l15/src/try_rng.rs
+++ b/embedded-cal-nrf54l15/src/try_rng.rs
@@ -1,0 +1,107 @@
+use crate::Nrf54l15Cal;
+use nrf_pac::cracencore::vals::{ControlSoftrst, State};
+const MAX_TRNG_RESTARTS: u32 = 3;
+
+/// Error returned by [`RngProvider::try_fill_bytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RngError {
+    /// The hardware noise source failed its internal health test too many times.
+    ///
+    /// This indicates the entropy source may be untrustworthy (degraded oscillator,
+    /// power instability, or a silicon fault).
+    HardwareFailure,
+}
+
+impl core::fmt::Display for RngError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RngError::HardwareFailure => write!(f, "hardware noise source failed health test"),
+        }
+    }
+}
+
+impl core::error::Error for RngError {}
+
+impl embedded_cal::TryRng for Nrf54l15Cal {
+    type Error = RngError;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        let mut bytes = [0u8; 4];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u32::from_le_bytes(bytes))
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut bytes = [0u8; 8];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        let mut dst = dst;
+        let mut restarts = 0;
+
+        while !dst.is_empty() {
+            // Check the TRNG FSM state before waiting on the FIFO.
+            //
+            // The CRACEN TRNG can enter State::ERROR when its internal health
+            // tests detect degraded entropy (NIST repetition/proportion test
+            // failure, AIS31 noise alarm, or startup failure). In that state
+            // the FIFO stops refilling and spinning on fifolevel() forever
+            // produces a hang. The recovery sequence mirrors sx_trng_restart()
+            // in sdk-nrf: pulse softrst CTEST→NORMAL then re-assert enable.
+            //
+            // Unlike transient startup/fill states (RESET, STARTUP, FILLFIFO),
+            // ERROR indicates the noise source itself may be untrustworthy, so
+            // we bound restarts: after MAX_TRNG_RESTARTS we return Err(HardwareFailure)
+            // rather than looping forever or handing out potentially non-random bytes.
+            let fsm = self.cracen_core.rngcontrol().status().read().state();
+            if fsm == State::ERROR {
+                restarts += 1;
+                if restarts > MAX_TRNG_RESTARTS {
+                    return Err(RngError::HardwareFailure);
+                }
+
+                // Pulse softrst to flush the conditioner and FIFO
+                self.cracen_core
+                    .rngcontrol()
+                    .control()
+                    .modify(|w| w.set_softrst(ControlSoftrst::CTEST));
+                self.cracen_core
+                    .rngcontrol()
+                    .control()
+                    .modify(|w| w.set_softrst(ControlSoftrst::NORMAL));
+                self.cracen_core
+                    .rngcontrol()
+                    .control()
+                    .modify(|w| w.set_enable(true));
+
+                continue;
+            }
+
+            let level = loop {
+                let l = self.cracen_core.rngcontrol().fifolevel().read();
+                if l > 0 {
+                    break l;
+                }
+                core::hint::spin_loop();
+            };
+
+            for _ in 0..level {
+                if dst.is_empty() {
+                    break;
+                }
+
+                // Always read fifo(0). The FIFO is a pop-on-read register; each read
+                // advances the hardware read pointer.
+                // Based on `cracen_get_random` from sdk-nrf C implementation
+                let bytes = self.cracen_core.rngcontrol().fifo(0).read().to_le_bytes();
+                let take = dst.len().min(4);
+                dst[..take].copy_from_slice(&bytes[..take]);
+                dst = &mut dst[take..];
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/embedded-cal-nrf54l15/src/try_rng.rs
+++ b/embedded-cal-nrf54l15/src/try_rng.rs
@@ -22,7 +22,8 @@ impl core::fmt::Display for RngError {
 
 impl core::error::Error for RngError {}
 
-impl embedded_cal::TryRng for Nrf54l15Cal {
+impl rand_core::TryCryptoRng for Nrf54l15Cal {}
+impl rand_core::TryRng for Nrf54l15Cal {
     type Error = RngError;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -36,4 +36,9 @@ mod tests {
         >();
         testvectors::test_hash_algorithm_sha256(&mut state.cal);
     }
+
+    #[test]
+    fn test_tryrng(state: &mut super::TestState) {
+        embedded_cal::test_tryrng(&mut state.cal);
+    }
 }

--- a/embedded-cal-software/Cargo.toml
+++ b/embedded-cal-software/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 
 [dependencies]
 embedded-cal = { version = "0.1.0", path = "../embedded-cal" }
+rand_core.workspace = true
 
 [dev-dependencies]
 testvectors.path = "../testvectors"

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -5,9 +5,11 @@
 #![no_std]
 
 use embedded_cal::{
-    Cal, HashProvider,
-    plumbing::Plumbing,
-    plumbing::hash::{SHA2SHORT_BLOCK_SIZE, Sha2Short, Sha2ShortVariant},
+    Cal, HashProvider, TryRng,
+    plumbing::{
+        Plumbing,
+        hash::{SHA2SHORT_BLOCK_SIZE, Sha2Short, Sha2ShortVariant},
+    },
 };
 
 pub trait ExtenderConfig {
@@ -27,6 +29,25 @@ pub struct Extender<EC: ExtenderConfig>(EC::Base);
 const HASH_WRAPPER_MAX_BLOCKSIZE: usize = 68;
 
 impl<EC: ExtenderConfig> embedded_cal::Cal for Extender<EC> {}
+
+impl<EC: ExtenderConfig> embedded_cal::TryRng for Extender<EC>
+where
+    EC::Base: TryRng,
+{
+    type Error = <EC::Base as TryRng>::Error;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        self.0.try_next_u32()
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        self.0.try_next_u64()
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.try_fill_bytes(dst)
+    }
+}
 
 impl<EC: ExtenderConfig> HashProvider for Extender<EC> {
     type Algorithm = HashAlgorithm<EC>;
@@ -243,27 +264,6 @@ pub enum HashState<EC: ExtenderConfig> {
         buffer: [u8; HASH_WRAPPER_MAX_BLOCKSIZE],
         instance: <EC::Base as Sha2Short>::State,
     },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    mod dummy_sha256;
-
-    struct ImplementSha256Short;
-
-    impl ExtenderConfig for ImplementSha256Short {
-        const IMPLEMENT_SHA2SHORT: bool = true;
-        type Base = dummy_sha256::DummySha256;
-    }
-
-    #[test]
-    fn test_hash_algorithm_sha256_on_dummy() {
-        let mut cal = Extender::<ImplementSha256Short>(dummy_sha256::DummySha256);
-
-        testvectors::test_hash_algorithm_sha256(&mut cal);
-    }
 }
 
 pub enum HashResult<EC: ExtenderConfig> {

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 use embedded_cal::{
-    Cal, HashProvider, TryRng,
+    Cal, HashProvider,
     plumbing::{
         Plumbing,
         hash::{SHA2SHORT_BLOCK_SIZE, Sha2Short, Sha2ShortVariant},
@@ -30,11 +30,16 @@ const HASH_WRAPPER_MAX_BLOCKSIZE: usize = 68;
 
 impl<EC: ExtenderConfig> embedded_cal::Cal for Extender<EC> {}
 
-impl<EC: ExtenderConfig> embedded_cal::TryRng for Extender<EC>
-where
-    EC::Base: TryRng,
+impl<EC: ExtenderConfig> rand_core::TryCryptoRng for Extender<EC> where
+    EC::Base: rand_core::TryCryptoRng
 {
-    type Error = <EC::Base as TryRng>::Error;
+}
+
+impl<EC: ExtenderConfig> rand_core::TryRng for Extender<EC>
+where
+    EC::Base: rand_core::TryRng,
+{
+    type Error = <EC::Base as rand_core::TryRng>::Error;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         self.0.try_next_u32()

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -11,8 +11,6 @@
 /// All implementation follows the Wikipedia pseudocode.
 pub struct DummySha256;
 
-impl embedded_cal::Cal for DummySha256 {}
-
 const k: [u32; 64] = [
     0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
     0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,

--- a/embedded-cal-stm32wba55/Cargo.toml
+++ b/embedded-cal-stm32wba55/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 [dependencies]
 embedded-cal.path = "../embedded-cal"
 stm32-metapac = { version = "18.0", features = ["stm32wba55cg", "rt"] }
+rand_core.workspace = true
 
 [dev-dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -1,22 +1,110 @@
 #![no_std]
 
-use stm32_metapac::{hash, rcc};
+use stm32_metapac::{
+    hash,
+    rcc::{self, vals::Rngsel},
+    rng::{
+        self,
+        vals::{Clkdiv, Htcfg, Nistc, RngConfig1, RngConfig2, RngConfig3},
+    },
+};
+mod try_rng;
 
 const WORD_SIZE: usize = 4;
 const CSR_REGS_LEN: usize = 54;
 
 pub struct Stm32wba55Cal {
     hash: hash::Hash,
+    rcc: rcc::Rcc,
+    rng: rng::Rng,
 }
 
 impl embedded_cal::Cal for Stm32wba55Cal {}
 
 impl Stm32wba55Cal {
-    pub fn new(hash: hash::Hash, rcc: &rcc::Rcc) -> Self {
-        // Enable HASH clock
-        rcc.ahb2enr().modify(|w| w.set_hashen(true));
+    pub fn new(hash: hash::Hash, rcc: rcc::Rcc, rng: rng::Rng) -> Self {
+        // Select HSI as the RNG kernel clock source (default is LSE which may not be running)
+        rcc.ccipr2().modify(|w| w.set_rngsel(Rngsel::HSI));
 
-        Self { hash }
+        // Enable HASH and RNG clocks
+        rcc.ahb2enr().modify(|w| {
+            w.set_hashen(true);
+            w.set_rngen(true);
+        });
+
+        let mut cal = Self { hash, rcc, rng };
+        cal.init_rng().expect("RNG init failed");
+        cal
+    }
+
+    /// Initialize the RNG peripheral using the rng_v3 conditioning sequence.
+    ///
+    /// Must be called once after enabling the RNG clock, and again on seed error recovery.
+    /// Uses NIST config A (certifiable). The HTCR magic number must precede any HTCR write
+    /// per the RM0493 requirement.
+    fn init_rng(&mut self) -> Result<(), try_rng::RngError> {
+        // Enter conditioning reset with NIST config A settings
+        self.rng.cr().write(|w| {
+            w.set_condrst(true);
+            w.set_nistc(Nistc::CUSTOM);
+            w.set_rng_config1(RngConfig1::CONFIG_A);
+            w.set_clkdiv(Clkdiv::NO_DIV);
+            w.set_rng_config2(RngConfig2::CONFIG_A_B);
+            w.set_rng_config3(RngConfig3::CONFIG_A);
+            w.set_ced(true); // disable clock error detection during conditioning
+            w.set_ie(false);
+            w.set_rngen(true);
+        });
+
+        // Wait for conditioning reset to take effect
+        wait_for(|| self.rng.cr().read().condrst())?;
+
+        // Write health test config: magic number must immediately precede the actual value
+        self.rng.htcr().write(|w| w.set_htcfg(Htcfg::MAGIC));
+        self.rng.htcr().write(|w| w.set_htcfg(Htcfg::RECOMMENDED));
+
+        // Clear conditioning reset and re-enable clock error detection
+        self.rng.cr().modify(|w| {
+            w.set_condrst(false);
+            w.set_ced(false); // re-enable clock error detection (was disabled during conditioning)
+        });
+
+        // Wait for conditioning reset to deassert (RM0493 requires waiting for both assert and deassert)
+        wait_for(|| !self.rng.cr().read().condrst())?;
+
+        // Clear any latched seed error from the reset
+        self.rng.sr().modify(|w| w.set_seis(false));
+
+        // Discard the first output word (required after every reset per RM0493).
+        // Also unblock on seis so a seed error during conditioning doesn't hang forever.
+        wait_for(|| {
+            let sr = self.rng.sr().read();
+            sr.drdy() || sr.seis()
+        })?;
+        if self.rng.sr().read().seis() {
+            return Err(try_rng::RngError::HardwareFailure);
+        }
+        let _ = self.rng.dr().read();
+
+        Ok(())
+    }
+}
+
+fn wait_for(mut condition: impl FnMut() -> bool) -> Result<(), try_rng::RngError> {
+    for _ in 0..1000 {
+        if condition() {
+            return Ok(());
+        }
+        core::hint::spin_loop();
+    }
+    Err(try_rng::RngError::HardwareFailure)
+}
+
+impl Drop for Stm32wba55Cal {
+    fn drop(&mut self) {
+        // Disable HASH clock
+        self.rcc.ahb2enr().modify(|w| w.set_hashen(false));
+        self.rng.cr().modify(|w| w.set_rngen(false));
     }
 }
 

--- a/embedded-cal-stm32wba55/src/try_rng.rs
+++ b/embedded-cal-stm32wba55/src/try_rng.rs
@@ -1,0 +1,85 @@
+use crate::Stm32wba55Cal;
+const MAX_SEED_RETRIES: u32 = 3;
+
+/// Error returned by [`RngProvider::try_fill_bytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RngError {
+    /// The hardware noise source failed its internal health test too many times.
+    ///
+    /// This indicates the entropy source may be untrustworthy (degraded oscillator,
+    /// power instability, or a silicon fault).
+    HardwareFailure,
+}
+
+impl core::fmt::Display for RngError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RngError::HardwareFailure => write!(f, "hardware noise source failed health test"),
+        }
+    }
+}
+
+impl core::error::Error for RngError {}
+
+impl embedded_cal::TryRng for Stm32wba55Cal {
+    type Error = RngError;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        let mut bytes = [0u8; 4];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u32::from_le_bytes(bytes))
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut bytes = [0u8; 8];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        let mut dst = dst;
+        let mut seed_errors: u32 = 0;
+
+        while !dst.is_empty() {
+            let sr = self.rng.sr().read();
+
+            if sr.seis() {
+                // Seed error: the hardware noise source failed its internal health
+                // test. Clear the flag and re-run the full NIST conditioning sequence.
+                //
+                // Unlike a clock error (ceis), which self-recovers once the clock
+                // stabilizes, seis indicates the entropy source itself may be
+                // degraded (bad oscillator, power instability, temperature extreme,
+                // or a silicon fault). Re-initializing in that case just loops back
+                // to the same failure, so we bound retries: after MAX_SEED_RETRIES
+                // consecutive seed errors we give up and return Err(()) rather than
+                // spinning forever or handing out potentially non-random bytes.
+                seed_errors += 1;
+                if seed_errors > MAX_SEED_RETRIES {
+                    return Err(RngError::HardwareFailure);
+                }
+                self.rng.sr().modify(|w| w.set_seis(false));
+                self.init_rng()?;
+                continue;
+            }
+
+            if sr.ceis() {
+                // Clock error: clear flag, hardware recovers automatically
+                self.rng.sr().modify(|w| w.set_ceis(false));
+                continue;
+            }
+
+            if sr.drdy() {
+                let bytes = self.rng.dr().read().to_le_bytes();
+                let take = dst.len().min(crate::WORD_SIZE);
+                dst[..take].copy_from_slice(&bytes[..take]);
+                dst = &mut dst[take..];
+                seed_errors = 0;
+            } else {
+                core::hint::spin_loop();
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/embedded-cal-stm32wba55/src/try_rng.rs
+++ b/embedded-cal-stm32wba55/src/try_rng.rs
@@ -21,7 +21,8 @@ impl core::fmt::Display for RngError {
 
 impl core::error::Error for RngError {}
 
-impl embedded_cal::TryRng for Stm32wba55Cal {
+impl rand_core::TryCryptoRng for Stm32wba55Cal {}
+impl rand_core::TryRng for Stm32wba55Cal {
     type Error = RngError;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {

--- a/embedded-cal-stm32wba55/tests/integration.rs
+++ b/embedded-cal-stm32wba55/tests/integration.rs
@@ -20,8 +20,11 @@ mod tests {
     use embedded_cal_stm32wba55::Stm32wba55Cal;
     #[init]
     fn init() -> super::TestState {
-        let base =
-            embedded_cal_stm32wba55::Stm32wba55Cal::new(stm32_metapac::HASH, &stm32_metapac::RCC);
+        let base = embedded_cal_stm32wba55::Stm32wba55Cal::new(
+            stm32_metapac::HASH,
+            stm32_metapac::RCC,
+            stm32_metapac::RNG,
+        );
 
         let cal = embedded_cal_software::Extender::<ImplementSha256Short>::new(base);
         super::TestState { cal }
@@ -33,5 +36,10 @@ mod tests {
             <Stm32wba55Cal as embedded_cal::HashProvider>::Algorithm,
         >();
         testvectors::test_hash_algorithm_sha256(&mut state.cal);
+    }
+
+    #[test]
+    fn test_tryrng(state: &mut super::TestState) {
+        embedded_cal::test_tryrng(&mut state.cal);
     }
 }

--- a/embedded-cal/Cargo.toml
+++ b/embedded-cal/Cargo.toml
@@ -12,3 +12,4 @@ version.workspace = true
 
 [dependencies]
 hax-lib.workspace = true
+rand_core.workspace = true

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
 mod hash;
+mod rng;
 // FIXME: Once we start API stability, this should be a dedicated crate.
 pub mod plumbing;
 
 pub use hash::{HashAlgorithm, HashProvider, NoHashAlgorithms, test_hash_algorithm_sha256};
+pub use rng::{TryRng, test_tryrng};
 
 pub trait Cal: HashProvider {}

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -6,6 +6,6 @@ mod rng;
 pub mod plumbing;
 
 pub use hash::{HashAlgorithm, HashProvider, NoHashAlgorithms, test_hash_algorithm_sha256};
-pub use rng::{TryRng, test_tryrng};
+pub use rng::test_tryrng;
 
 pub trait Cal: HashProvider {}

--- a/embedded-cal/src/rng.rs
+++ b/embedded-cal/src/rng.rs
@@ -1,13 +1,4 @@
-// Based on rand_core::TryRng
-pub trait TryRng {
-    type Error: core::error::Error;
-
-    fn try_next_u32(&mut self) -> Result<u32, Self::Error>;
-    fn try_next_u64(&mut self) -> Result<u64, Self::Error>;
-    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error>;
-}
-
-pub fn test_tryrng<R: TryRng>(rng: &mut R) {
+pub fn test_tryrng<R: rand_core::TryCryptoRng>(rng: &mut R) {
     // Zero-length fill must not panic
     rng.try_fill_bytes(&mut []).unwrap();
 

--- a/embedded-cal/src/rng.rs
+++ b/embedded-cal/src/rng.rs
@@ -1,0 +1,40 @@
+// Based on rand_core::TryRng
+pub trait TryRng {
+    type Error: core::error::Error;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error>;
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error>;
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error>;
+}
+
+pub fn test_tryrng<R: TryRng>(rng: &mut R) {
+    // Zero-length fill must not panic
+    rng.try_fill_bytes(&mut []).unwrap();
+
+    // Single-byte fill exercises the take=1 path
+    let mut one = [0u8; 1];
+    rng.try_fill_bytes(&mut one).unwrap();
+
+    // Basic fill: output should not be all zeros
+    let mut buf = [0u8; 32];
+    rng.try_fill_bytes(&mut buf).unwrap();
+    assert!(buf.iter().any(|&b| b != 0));
+
+    // Two consecutive fills should differ
+    let mut buf2 = [0u8; 32];
+    rng.try_fill_bytes(&mut buf2).unwrap();
+    assert_ne!(buf, buf2);
+
+    // Non-multiple-of-4 length exercises the partial last word path
+    let mut buf3 = [0u8; 15];
+    rng.try_fill_bytes(&mut buf3).unwrap();
+    assert!(buf3.iter().any(|&b| b != 0));
+
+    // Fill larger than a typical FIFO depth (>64 bytes) exercises multi-iteration draining
+    let mut large = [0u8; 128];
+    rng.try_fill_bytes(&mut large).unwrap();
+    assert!(large.iter().any(|&b| b != 0));
+
+    let _ = rng.try_next_u32().unwrap();
+    let _ = rng.try_next_u64().unwrap();
+}


### PR DESCRIPTION
This PR add the `TryRng` trait and hardware impl for nRF54L15 and STM32WBA55

The `TryRng` was based on the `rand_core::TryRng` trait (should we just add as a dependency and impl?)

Summary

  - Introduces a TryRng trait in embedded-cal (modelled after rand_core::TryRng) with try_next_u32, try_next_u64, and try_fill_bytes methods, plus a shared test_tryrng helper for back-end
  validation
  - Implements TryRng for the nRF54L15 back-end (embedded-cal-nrf54l15) using the CRACEN RNG hardware
  - Implements TryRng for the STM32WBA55 back-end (embedded-cal-stm32wba55) using the on-chip RNG peripheral