### PR TITLE
feat: clippy on all workspaces

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: run `cargo check`
       run: RUSTFLAGS="-D warnings" cargo check
     - name: run `cargo clippy`
-      run: cargo clippy -- --deny clippy::all
+      run: cargo clippy --workspace -- --deny clippy::all
     - name: run `cargo doc`
       run: RUSTDOCFLAGS="-D warnings" cargo doc
     - name: run `cargo test`

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -137,7 +137,7 @@ impl<'mem, Direction, const N: usize> DescriptorChain<'mem, Direction, N> {
     /// To make that operation safe, `f` must wait until END or ERROR is observed on the relevant
     /// EasyDMA. It must not return **or panic** between starting the DMA operation and observing
     /// its completion.
-    pub(crate) fn with_first_pointer(&mut self, f: impl FnOnce(u32) -> ()) {
+    pub(crate) fn with_first_pointer(&mut self, f: impl FnOnce(u32)) {
         f(self.first())
     }
 }

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -177,7 +177,7 @@ impl<'mem, const N: usize> DescriptorChain<'mem, Output, N> {
 const fn sz(n: usize) -> u32 {
     const DMA_REALIGN: usize = 0x2000_0000;
     debug_assert!(
-        n % 4 == 0,
+        n.is_multiple_of(4),
         "Sizes passed through this function need to be in multiples of the word size"
     );
     (n | DMA_REALIGN) as u32

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -104,7 +104,7 @@ impl embedded_cal::plumbing::hash::Sha2Short for Nrf54l15Cal {
 
     fn update(&mut self, instance: &mut Self::State, data: &[u8]) {
         debug_assert!(
-            data.len() % 64 == 0,
+            data.len().is_multiple_of(64),
             "Chunking requirements laid out in Self::FIRST_CHUNK_SIZE not upheld."
         );
 
@@ -147,7 +147,7 @@ impl Nrf54l15Cal {
         &mut self,
         input_descriptors: &mut DescriptorChain<Input, N>,
         output_descriptors: &mut DescriptorChain<Output, N>,
-    ) -> () {
+    ) {
         input_descriptors.with_first_pointer(|input_ptr| {
             output_descriptors.with_first_pointer(|output_ptr| {
                 let dma = self.cracen_core.cryptmstrdma();

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -245,27 +245,6 @@ pub enum HashState<EC: ExtenderConfig> {
     },
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    mod dummy_sha256;
-
-    struct ImplementSha256Short;
-
-    impl ExtenderConfig for ImplementSha256Short {
-        const IMPLEMENT_SHA2SHORT: bool = true;
-        type Base = dummy_sha256::DummySha256;
-    }
-
-    #[test]
-    fn test_hash_algorithm_sha256_on_dummy() {
-        let mut cal = Extender::<ImplementSha256Short>(dummy_sha256::DummySha256);
-
-        testvectors::test_hash_algorithm_sha256(&mut cal);
-    }
-}
-
 pub enum HashResult<EC: ExtenderConfig> {
     Sha256([u8; 32]),
     Direct(<EC::Base as HashProvider>::HashResult),
@@ -314,4 +293,24 @@ fn sha2_padding(
     out[start..start + length_bytes].copy_from_slice(&len_bytes_be[(16 - length_bytes)..]);
 
     1 + zero_pad + length_bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    mod dummy_sha256;
+
+    struct ImplementSha256Short;
+
+    impl ExtenderConfig for ImplementSha256Short {
+        const IMPLEMENT_SHA2SHORT: bool = true;
+        type Base = dummy_sha256::DummySha256;
+    }
+
+    #[test]
+    fn test_hash_algorithm_sha256_on_dummy() {
+        let mut cal = Extender::<ImplementSha256Short>(dummy_sha256::DummySha256);
+
+        testvectors::test_hash_algorithm_sha256(&mut cal);
+    }
 }

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -33,7 +33,7 @@ impl embedded_cal::HashProvider for DummySha256 {
         match algorithm {}
     }
 
-    fn update(&mut self, instance: &mut Self::HashState, data: &[u8]) {
+    fn update(&mut self, instance: &mut Self::HashState, _data: &[u8]) {
         match *instance {}
     }
 
@@ -73,7 +73,7 @@ impl embedded_cal::plumbing::hash::Sha2Short for DummySha256 {
         assert!(data.len() == 64, "Not feeding exactly 512bit");
 
         let mut w: [u32; 64] = [0; _]; // or uninit
-        for (i, chunkword) in data.as_chunks::<4>().0.into_iter().enumerate() {
+        for (i, chunkword) in data.as_chunks::<4>().0.iter().enumerate() {
             w[i] = u32::from_be_bytes(*chunkword);
         }
 

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -155,7 +155,7 @@ impl Stm32wba55Cal {
 
         // Save CSR registers (0..37 always; 38..53 only for HMAC)
         let mut csr = [0u32; CSR_REGS_LEN];
-        for (i, slot) in csr.iter_mut().enumerate().take(CSR_REGS_LEN) {
+        for (i, slot) in csr.iter_mut().enumerate() {
             *slot = self.hash.csr(i).read();
         }
         instance.context = Some(Context { csr, str, imr });
@@ -204,7 +204,7 @@ impl Stm32wba55Cal {
     }
 
     fn read_digest(&mut self, out: &mut [u32; 8]) {
-        for (i, slot) in out.iter_mut().enumerate().take(8) {
+        for (i, slot) in out.iter_mut().enumerate() {
             *slot = self.hash.hr(i).read();
         }
     }

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -155,8 +155,8 @@ impl Stm32wba55Cal {
 
         // Save CSR registers (0..37 always; 38..53 only for HMAC)
         let mut csr = [0u32; CSR_REGS_LEN];
-        for i in 0..CSR_REGS_LEN {
-            csr[i] = self.hash.csr(i).read();
+        for (i, slot) in csr.iter_mut().enumerate().take(CSR_REGS_LEN) {
+            *slot = self.hash.csr(i).read();
         }
         instance.context = Some(Context { csr, str, imr });
     }
@@ -204,8 +204,8 @@ impl Stm32wba55Cal {
     }
 
     fn read_digest(&mut self, out: &mut [u32; 8]) {
-        for i in 0..8 {
-            out[i] = self.hash.hr(i).read();
+        for (i, slot) in out.iter_mut().enumerate().take(8) {
+            *slot = self.hash.hr(i).read();
         }
     }
 }


### PR DESCRIPTION
After splitting the workspace into `members` and `default-members` to not run tests on every workspace, it also made clippy only run on default members. This PR fix that.


clippy::needless-range-loop, clippy::into-iter-on-ref, unused_variables, unnecessary-cast, unused-unit, manual-is-multiple-of