### PR TITLE
Add HmacProvider trait and implementation for SHA256

### DIFF
--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -79,6 +79,24 @@ impl embedded_cal::HashProvider for Nrf54l15Cal {
     }
 }
 
+impl embedded_cal::HmacProvider for Nrf54l15Cal {
+    type Algorithm = embedded_cal::NoHmacAlgorithms;
+    type HmacState = embedded_cal::NoHmacAlgorithms;
+    type HmacResult = embedded_cal::NoHmacAlgorithms;
+
+    fn init(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+        match algorithm {}
+    }
+
+    fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {
+        match *state {}
+    }
+
+    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult {
+        match state {}
+    }
+}
+
 impl embedded_cal::plumbing::Plumbing for Nrf54l15Cal {}
 
 impl embedded_cal::plumbing::hash::Hash for Nrf54l15Cal {}

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -36,4 +36,12 @@ mod tests {
         >();
         testvectors::test_hash_algorithm_sha256(&mut state.cal);
     }
+
+    #[test]
+    fn test_hmac_sha256(state: &mut super::TestState) {
+        embedded_cal::test_hmac_algorithm_hmacsha256::<
+            <embedded_cal_software::Extender<ImplementSha256Short> as embedded_cal::HmacProvider>::Algorithm,
+        >();
+        testvectors::test_hmac_sha256(&mut state.cal);
+    }
 }

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 use embedded_cal::{
-    Cal, HashProvider, HmacProvider,
+    HashProvider, HmacProvider,
     plumbing::Plumbing,
     plumbing::hash::{SHA2SHORT_BLOCK_SIZE, Sha2Short, Sha2ShortVariant},
 };
@@ -13,7 +13,7 @@ use embedded_cal::{
 pub trait ExtenderConfig {
     const IMPLEMENT_SHA2SHORT: bool;
 
-    type Base: Cal + Plumbing;
+    type Base: HashProvider + Plumbing;
 }
 
 impl<EC: ExtenderConfig> Extender<EC> {

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -422,4 +422,11 @@ mod tests {
 
         testvectors::test_hash_algorithm_sha256(&mut cal);
     }
+
+    #[test]
+    fn test_hmac_sha256_on_dummy() {
+        let mut cal = Extender::<ImplementSha256Short>(dummy_sha256::DummySha256);
+
+        testvectors::test_hmac_sha256(&mut cal);
+    }
 }

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 use embedded_cal::{
-    Cal, HashProvider,
+    Cal, HashProvider, HmacProvider,
     plumbing::Plumbing,
     plumbing::hash::{SHA2SHORT_BLOCK_SIZE, Sha2Short, Sha2ShortVariant},
 };
@@ -123,7 +123,7 @@ impl<EC: ExtenderConfig> HashProvider for Extender<EC> {
                         buffer,
                         instance,
                     };
-                    self.update(&mut rewrapped, &padding[..padding_size]);
+                    HashProvider::update(self, &mut rewrapped, &padding[..padding_size]);
                     let HashState::Sha256 {
                         instance, buffer, ..
                     } = rewrapped
@@ -255,6 +255,115 @@ impl<EC: ExtenderConfig> AsRef<[u8]> for HashResult<EC> {
         match self {
             HashResult::Sha256(data) => data.as_slice(),
             HashResult::Direct(result) => result.as_ref(),
+        }
+    }
+}
+
+/// HMAC algorithm identifier for software HMAC over [`Extender`].
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum HmacAlgorithm {
+    HmacSha256,
+}
+
+impl embedded_cal::HmacAlgorithm for HmacAlgorithm {
+    fn len(&self) -> usize {
+        match self {
+            HmacAlgorithm::HmacSha256 => 32,
+        }
+    }
+
+    #[inline]
+    fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
+        match number.into() {
+            5 => Some(HmacAlgorithm::HmacSha256),
+            _ => None,
+        }
+    }
+}
+
+pub enum HmacState<EC: ExtenderConfig> {
+    HmacSha256 {
+        /// Inner hash state accumulating `H((K XOR ipad) || message)`.
+        inner: HashState<EC>,
+        /// Key material XORed with opad, ready for the outer hash in `finalize`.
+        outer_key: [u8; SHA2SHORT_BLOCK_SIZE],
+    },
+}
+
+pub enum HmacResult {
+    HmacSha256([u8; 32]),
+}
+
+impl AsRef<[u8]> for HmacResult {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            HmacResult::HmacSha256(data) => data.as_slice(),
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
+    type Algorithm = HmacAlgorithm;
+    type HmacState = HmacState<EC>;
+    type HmacResult = HmacResult;
+
+    fn init(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+        match algorithm {
+            HmacAlgorithm::HmacSha256 => {
+                // Normalise key to exactly SHA2SHORT_BLOCK_SIZE bytes.
+                // If key is longer than the block size, hash it first (RFC 2104).
+                let mut key_block = [0u8; SHA2SHORT_BLOCK_SIZE];
+                if key.len() > SHA2SHORT_BLOCK_SIZE {
+                    let hashed = HashProvider::hash(self, HashAlgorithm::Sha256, key);
+                    let h = hashed.as_ref();
+                    debug_assert_eq!(h.len(), 32, "SHA-256 must produce 32 bytes");
+                    key_block[..h.len()].copy_from_slice(h);
+                } else {
+                    key_block[..key.len()].copy_from_slice(key);
+                }
+
+                // outer_key = key_block XOR opad (0x5c)
+                let mut outer_key = [0u8; SHA2SHORT_BLOCK_SIZE];
+                for (o, &k) in outer_key.iter_mut().zip(key_block.iter()) {
+                    *o = k ^ 0x5c;
+                }
+
+                // ipad_block = key_block XOR ipad (0x36)
+                let mut ipad_block = [0u8; SHA2SHORT_BLOCK_SIZE];
+                for (i, &k) in ipad_block.iter_mut().zip(key_block.iter()) {
+                    *i = k ^ 0x36;
+                }
+
+                // Start inner hash: H((key XOR ipad) || ...)
+                let mut inner = HashProvider::init(self, HashAlgorithm::Sha256);
+                HashProvider::update(self, &mut inner, &ipad_block);
+
+                HmacState::HmacSha256 { inner, outer_key }
+            }
+        }
+    }
+
+    fn update(&mut self, state: &mut Self::HmacState, data: &[u8]) {
+        match state {
+            HmacState::HmacSha256 { inner, .. } => {
+                HashProvider::update(self, inner, data);
+            }
+        }
+    }
+
+    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult {
+        match state {
+            HmacState::HmacSha256 { inner, outer_key } => {
+                // Finish inner hash, then compute outer: H(outer_key || inner_result)
+                let inner_result = HashProvider::finalize(self, inner);
+                let mut outer = HashProvider::init(self, HashAlgorithm::Sha256);
+                HashProvider::update(self, &mut outer, &outer_key);
+                HashProvider::update(self, &mut outer, inner_result.as_ref());
+                match HashProvider::finalize(self, outer) {
+                    HashResult::Sha256(buf) => HmacResult::HmacSha256(buf),
+                    _ => unreachable!("Sha256 init produces Sha256 result"),
+                }
+            }
         }
     }
 }

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -42,6 +42,24 @@ impl embedded_cal::HashProvider for DummySha256 {
     }
 }
 
+impl embedded_cal::HmacProvider for DummySha256 {
+    type Algorithm = embedded_cal::NoHmacAlgorithms;
+    type HmacState = embedded_cal::NoHmacAlgorithms;
+    type HmacResult = embedded_cal::NoHmacAlgorithms;
+
+    fn init(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+        match algorithm {}
+    }
+
+    fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {
+        match *state {}
+    }
+
+    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult {
+        match state {}
+    }
+}
+
 impl embedded_cal::plumbing::Plumbing for DummySha256 {}
 
 impl embedded_cal::plumbing::hash::Hash for DummySha256 {}

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -57,6 +57,24 @@ impl embedded_cal::HashProvider for Stm32wba55Cal {
     }
 }
 
+impl embedded_cal::HmacProvider for Stm32wba55Cal {
+    type Algorithm = embedded_cal::NoHmacAlgorithms;
+    type HmacState = embedded_cal::NoHmacAlgorithms;
+    type HmacResult = embedded_cal::NoHmacAlgorithms;
+
+    fn init(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+        match algorithm {}
+    }
+
+    fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {
+        match *state {}
+    }
+
+    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult {
+        match state {}
+    }
+}
+
 impl embedded_cal::plumbing::Plumbing for Stm32wba55Cal {}
 
 impl embedded_cal::plumbing::hash::Hash for Stm32wba55Cal {}

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -1,9 +1,13 @@
 #![no_std]
 
+use embedded_cal::plumbing::hash::SHA2SHORT_BLOCK_SIZE;
 use stm32_metapac::{hash, rcc};
 
 const WORD_SIZE: usize = 4;
 const CSR_REGS_LEN: usize = 54;
+/// Block size for SHA-256 (and the HMAC message phase).
+const HMAC_MAX_BLOCK_SIZE: usize = 68;
+const SHA256_OUT_BYTES: usize = 32;
 
 pub struct Stm32wba55Cal {
     hash: hash::Hash,
@@ -57,21 +61,176 @@ impl embedded_cal::HashProvider for Stm32wba55Cal {
     }
 }
 
+/// HMAC algorithm identifier for the STM32WBA55 hardware accelerator.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum HmacAlgorithm {
+    HmacSha256,
+}
+
+impl embedded_cal::HmacAlgorithm for HmacAlgorithm {
+    fn len(&self) -> usize {
+        match self {
+            HmacAlgorithm::HmacSha256 => 32,
+        }
+    }
+
+    fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
+        match number.into() {
+            5 => Some(HmacAlgorithm::HmacSha256),
+            _ => None,
+        }
+    }
+}
+
+/// State for an in-progress HMAC-SHA256 operation.
+pub struct HmacState {
+    /// Saved HASH hardware context (captured after each block written to hardware).
+    context: Option<Context>,
+    /// Buffer for accumulating a full 64-byte (68 on the first call) block before sending to hardware.
+    buf: [u8; HMAC_MAX_BLOCK_SIZE],
+    /// Number of valid bytes in `buf`.
+    buf_len: usize,
+    /// Key normalised to one SHA-256 block (64 bytes): hashed if oversized, else zero-padded.
+    /// Fed to the hardware as the outer key in `finalize`.
+    key_block: [u8; SHA2SHORT_BLOCK_SIZE],
+}
+
+/// HMAC-SHA256 output from the STM32WBA55 hardware accelerator.
+pub struct HmacResult([u8; 32]);
+
+impl AsRef<[u8]> for HmacResult {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl embedded_cal::HmacProvider for Stm32wba55Cal {
-    type Algorithm = embedded_cal::NoHmacAlgorithms;
-    type HmacState = embedded_cal::NoHmacAlgorithms;
-    type HmacResult = embedded_cal::NoHmacAlgorithms;
+    type Algorithm = HmacAlgorithm;
+    type HmacState = HmacState;
+    type HmacResult = HmacResult;
 
-    fn init(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
-        match algorithm {}
+    fn init(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+        match algorithm {
+            HmacAlgorithm::HmacSha256 => {
+                // Normalise key: zero-pad short keys; hash long keys per RFC 2104.
+                let mut key_block = [0u8; SHA2SHORT_BLOCK_SIZE];
+                if key.len() > SHA2SHORT_BLOCK_SIZE {
+                    let hashed = self.sha256_of(key);
+                    key_block[..SHA256_OUT_BYTES].copy_from_slice(&hashed);
+                } else {
+                    key_block[..key.len()].copy_from_slice(key);
+                }
+
+                // Initialise the HASH peripheral in HMAC-SHA256 mode.
+                self.hash.cr().write(|w| {
+                    w.set_mode(true); // HMAC
+                    w.set_dmae(false);
+                    w.set_algo(3); // SHA-256
+                    w.set_datatype(0); // 32-bit words, no byte-swap
+                    w.set_lkey(false); // always false, because we save the key as sha-256
+                    w.set_init(true);
+                });
+                while self.hash.cr().read().init() {}
+
+                // Feed the inner key (64 bytes = 16 full 32-bit words).
+                for chunk in key_block.chunks_exact(WORD_SIZE) {
+                    let mut bytes = [0u8; WORD_SIZE];
+                    bytes.copy_from_slice(chunk);
+                    self.hash.din().write_value(u32::from_be_bytes(bytes));
+                }
+                // NBLW = 0: all 16 words are full (no partial last word).
+                self.hash.str().write(|w| w.set_nblw(0));
+                self.hash.str().write(|w| w.set_dcal(true));
+
+                // Wait until the hardware has processed the key and is ready for message data.
+                while !self.hash.sr().read().dinis() {}
+
+                HmacState {
+                    context: Some(self.read_context()),
+                    buf: [0; HMAC_MAX_BLOCK_SIZE],
+                    buf_len: 0,
+                    key_block,
+                }
+            }
+        }
     }
 
-    fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {
-        match *state {}
+    fn update(&mut self, state: &mut Self::HmacState, data: &[u8]) {
+        let mut remaining = data;
+        let mut wrote_blocks = false;
+
+        while !remaining.is_empty() {
+            let hmac_block_size = self.hash.sr().read().nbwe() as usize * WORD_SIZE;
+            let space = hmac_block_size - state.buf_len;
+            let take = remaining.len().min(space);
+            state.buf[state.buf_len..state.buf_len + take].copy_from_slice(&remaining[..take]);
+            state.buf_len += take;
+            remaining = &remaining[take..];
+
+            if state.buf_len == hmac_block_size {
+                if !wrote_blocks {
+                    //  Restore hardware context before the first write of this call.
+                    if let Some(ctx) = state.context.take() {
+                        self.restore_context_hmac(&ctx);
+                    }
+                    wrote_blocks = true;
+                }
+                // Write a complete 64-byte block (16 words) to the hardware.
+                for chunk in state.buf[..state.buf_len].chunks_exact(WORD_SIZE) {
+                    let mut bytes = [0u8; WORD_SIZE];
+                    bytes.copy_from_slice(chunk);
+                    self.hash.din().write_value(u32::from_be_bytes(bytes));
+                }
+                state.buf_len = 0;
+            }
+        }
+
+        if wrote_blocks {
+            // Capture the updated hardware context for the next call.
+            state.context = Some(self.read_context());
+        }
     }
 
-    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult {
-        match state {}
+    fn finalize(&mut self, mut state: Self::HmacState) -> Self::HmacResult {
+        // Restore hardware to the last saved context.
+        if let Some(ctx) = state.context.take() {
+            self.restore_context_hmac(&ctx);
+        }
+
+        // Write the remaining buffered bytes (the last, possibly partial, message block).
+        let buf_len = state.buf_len;
+        for chunk in state.buf[..buf_len].chunks(WORD_SIZE) {
+            let mut bytes = [0u8; WORD_SIZE];
+            bytes[..chunk.len()].copy_from_slice(chunk);
+            self.hash.din().write_value(u32::from_be_bytes(bytes));
+        }
+        // NBLW: number of valid bits in the last word (0 = full 32-bit word).
+        let nblw = (buf_len % WORD_SIZE) as u8 * 8;
+        self.hash.str().write(|w| w.set_nblw(nblw));
+        self.hash.str().write(|w| w.set_dcal(true));
+        while !self.hash.sr().read().dinis() {}
+
+        // Feed the outer key (same 64-byte block as the inner key).
+        for chunk in state.key_block.chunks_exact(WORD_SIZE) {
+            let mut bytes = [0u8; WORD_SIZE];
+            bytes.copy_from_slice(chunk);
+            self.hash.din().write_value(u32::from_be_bytes(bytes));
+        }
+        // NBLW = 0: all 16 words of the outer key are full.
+        self.hash.str().write(|w| w.set_nblw(0));
+        self.hash.str().write(|w| w.set_dcal(true));
+
+        // Wait for DCIS: HMAC digest is ready.
+        self.wait_busy();
+
+        let mut words = [0u32; 8];
+        self.read_digest(&mut words);
+
+        let mut result = [0u8; 32];
+        for (i, w) in words.iter().enumerate() {
+            result[i * WORD_SIZE..(i + 1) * WORD_SIZE].copy_from_slice(&w.to_be_bytes());
+        }
+        HmacResult(result)
     }
 }
 
@@ -164,19 +323,25 @@ impl Stm32wba55Cal {
     /// Used to suspend processing of the current message.
     /// https://www.st.com/resource/en/reference_manual/rm0493-multiprotocol-wireless-bluetooth-lowenergy-armbased-32bit-mcu-stmicroelectronics.pdf
     fn save_context(&mut self, instance: &mut HashState) {
+        instance.context = Some(self.read_context());
+    }
+
+    /// Reads and returns the current HASH hardware context (IMR, STR, and all CSRs).
+    ///
+    /// Waits for BUSY = 0 before reading, as required by the suspend/resume procedure.
+    fn read_context(&mut self) -> Context {
         // BUSY must be 0
         while self.hash.sr().read().busy() {}
 
-        // Save IMR + STR registers
         let imr = self.hash.imr().read();
         let str = self.hash.str().read();
 
-        // Save CSR registers (0..37 always; 38..53 only for HMAC)
+        // Save CSR registers (0..37 always; 38..53 also needed for HMAC)
         let mut csr = [0u32; CSR_REGS_LEN];
         for (i, slot) in csr.iter_mut().enumerate() {
             *slot = self.hash.csr(i).read();
         }
-        instance.context = Some(Context { csr, str, imr });
+        Context { csr, str, imr }
     }
 
     /// As documented in the HASH suspend/resume procedure.
@@ -202,6 +367,56 @@ impl Stm32wba55Cal {
         for i in 0..CSR_REGS_LEN {
             self.hash.csr(i).write_value(ctx.csr[i])
         }
+    }
+
+    /// Resume an interrupted HMAC-SHA256 operation.
+    ///
+    /// Identical to [`restore_context`] but sets `MODE = 1` (HMAC) and `LKEY = 0`.
+    fn restore_context_hmac(&mut self, ctx: &Context) {
+        self.hash.cr().write(|w| w.set_init(false));
+        self.hash.imr().write_value(ctx.imr);
+        self.hash.str().write_value(ctx.str);
+        self.hash.cr().write(|w| {
+            w.set_mode(true); // HMAC mode
+            w.set_dmae(false);
+            w.set_algo(3); // SHA2-256
+            w.set_datatype(0);
+            w.set_lkey(false);
+        });
+        self.hash.cr().modify(|w| w.set_init(true));
+        while self.hash.cr().read().init() {}
+        for i in 0..CSR_REGS_LEN {
+            self.hash.csr(i).write_value(ctx.csr[i]);
+        }
+    }
+
+    /// Compute SHA-256 of `data` using the hardware accelerator.
+    ///
+    /// Used internally to hash HMAC keys that are longer than 64 bytes (RFC 2104).
+    fn sha256_of(&mut self, data: &[u8]) -> [u8; 32] {
+        use embedded_cal::plumbing::hash::{SHA2SHORT_BLOCK_SIZE, Sha2Short, Sha2ShortVariant};
+
+        let mut instance = <Self as Sha2Short>::init(self, Sha2ShortVariant::Sha256);
+        let mut remaining = data;
+        let mut first = true;
+
+        loop {
+            let chunk_size = if first {
+                <Self as Sha2Short>::FIRST_CHUNK_SIZE
+            } else {
+                SHA2SHORT_BLOCK_SIZE
+            };
+            if remaining.len() <= chunk_size {
+                break;
+            }
+            <Self as Sha2Short>::update(self, &mut instance, &remaining[..chunk_size]);
+            remaining = &remaining[chunk_size..];
+            first = false;
+        }
+
+        let mut output = [0u8; 32];
+        <Self as Sha2Short>::finalize(self, instance, remaining, &mut output);
+        output
     }
 
     fn wait_busy(&mut self) {

--- a/embedded-cal-stm32wba55/tests/integration.rs
+++ b/embedded-cal-stm32wba55/tests/integration.rs
@@ -34,4 +34,12 @@ mod tests {
         >();
         testvectors::test_hash_algorithm_sha256(&mut state.cal);
     }
+
+    #[test]
+    fn test_hmac_sha256(state: &mut super::TestState) {
+        embedded_cal::test_hmac_algorithm_hmacsha256::<
+            <embedded_cal_software::Extender<ImplementSha256Short> as embedded_cal::HmacProvider>::Algorithm,
+        >();
+        testvectors::test_hmac_sha256(&mut state.cal);
+    }
 }

--- a/embedded-cal-stm32wba55/tests/integration.rs
+++ b/embedded-cal-stm32wba55/tests/integration.rs
@@ -11,7 +11,10 @@ impl embedded_cal_software::ExtenderConfig for ImplementSha256Short {
 }
 
 struct TestState {
+    /// Software-extended CAL used for the SHA-256 hash tests.
     cal: embedded_cal_software::Extender<ImplementSha256Short>,
+    /// Raw STM32WBA55 CAL used to exercise the hardware HMAC accelerator directly.
+    raw: embedded_cal_stm32wba55::Stm32wba55Cal,
 }
 
 #[defmt_test::tests]
@@ -20,11 +23,15 @@ mod tests {
     use embedded_cal_stm32wba55::Stm32wba55Cal;
     #[init]
     fn init() -> super::TestState {
+        // stm32_metapac::HASH is a `const`, so it can be used at two sites
+        // without conflict; both values alias the same hardware register block.
+        // Tests run sequentially so there is no concurrent access.
+        let raw =
+            embedded_cal_stm32wba55::Stm32wba55Cal::new(stm32_metapac::HASH, &stm32_metapac::RCC);
         let base =
             embedded_cal_stm32wba55::Stm32wba55Cal::new(stm32_metapac::HASH, &stm32_metapac::RCC);
-
         let cal = embedded_cal_software::Extender::<ImplementSha256Short>::new(base);
-        super::TestState { cal }
+        super::TestState { cal, raw }
     }
 
     #[test]
@@ -38,8 +45,9 @@ mod tests {
     #[test]
     fn test_hmac_sha256(state: &mut super::TestState) {
         embedded_cal::test_hmac_algorithm_hmacsha256::<
-            <embedded_cal_software::Extender<ImplementSha256Short> as embedded_cal::HmacProvider>::Algorithm,
+            <Stm32wba55Cal as embedded_cal::HmacProvider>::Algorithm,
         >();
-        testvectors::test_hmac_sha256(&mut state.cal);
+        // Runs directly against the hardware HMAC accelerator (MODE=1 in HASH_CR).
+        testvectors::test_hmac_sha256(&mut state.raw);
     }
 }

--- a/embedded-cal/src/hmac.rs
+++ b/embedded-cal/src/hmac.rs
@@ -1,0 +1,71 @@
+pub trait HmacProvider {
+    type Algorithm: HmacAlgorithm;
+    /// State carried between rounds of feeding data into the HMAC.
+    type HmacState: Sized;
+    /// Output of an HMAC operation.
+    type HmacResult: AsRef<[u8]>;
+
+    fn init(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState;
+    fn update(&mut self, state: &mut Self::HmacState, data: &[u8]);
+    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult;
+
+    /// Compute HMAC over contiguous in-memory data in a single pass.
+    fn hmac(&mut self, algorithm: Self::Algorithm, key: &[u8], data: &[u8]) -> Self::HmacResult {
+        let mut state = self.init(algorithm, key);
+        self.update(&mut state, data);
+        self.finalize(state)
+    }
+}
+
+/// An HMAC algorithm identifier.
+#[allow(
+    clippy::len_without_is_empty,
+    reason = "Lint only makes sense when length can reasonably be zero, which is not the case here."
+)]
+pub trait HmacAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
+    /// Output length in bytes.
+    fn len(&self) -> usize;
+
+    /// Selects an HMAC algorithm from its COSE number.
+    ///
+    /// The algorithm number comes from the ["COSE Algorithms"
+    /// registry](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) maintained by IANA.
+    #[inline]
+    #[allow(
+        unused_variables,
+        reason = "Argument names are part of the documentation"
+    )]
+    fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
+        None
+    }
+}
+
+/// Type which an implementation of [`Cal`][crate::Cal] can use when it implements no HMAC
+/// algorithm for [`HmacProvider`].
+///
+/// This type is uninhabited and can stand in for all of the [`Algorithm`][HmacProvider::Algorithm],
+/// [`HmacState`][HmacProvider::HmacState] and [`HmacResult`][HmacProvider::HmacResult] associated
+/// types.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum NoHmacAlgorithms {}
+
+impl HmacAlgorithm for NoHmacAlgorithms {
+    fn len(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl AsRef<[u8]> for NoHmacAlgorithms {
+    fn as_ref(&self) -> &[u8] {
+        match *self {}
+    }
+}
+
+pub fn test_hmac_algorithm_hmacsha256<HA: HmacAlgorithm>() {
+    let cose_5 = HA::from_cose_number(5i8);
+    assert!(
+        cose_5.is_some(),
+        "HMAC 256/256 must be recognised by COSE number 5"
+    );
+    assert_eq!(cose_5.as_ref().map(|a| a.len()), Some(32));
+}

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
 mod hash;
+mod hmac;
 // FIXME: Once we start API stability, this should be a dedicated crate.
 pub mod plumbing;
 
 pub use hash::{HashAlgorithm, HashProvider, NoHashAlgorithms, test_hash_algorithm_sha256};
+pub use hmac::{HmacAlgorithm, HmacProvider, NoHmacAlgorithms, test_hmac_algorithm_hmacsha256};
 
-pub trait Cal: HashProvider {}
+pub trait Cal: HashProvider + HmacProvider {}

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -44,6 +44,79 @@ pub const SHA256HASHES: &[(&[u8], [u8; 32])] = &[
     ),
 ];
 
+/// HMAC-SHA256 test vectors from RFC 4231, test cases 1–4, 6–7.
+///
+/// Each entry is `(key, data, expected_mac)`.
+pub const HMAC_SHA256: &[(&[u8], &[u8], [u8; 32])] = &[
+    // TC1 — short key, short data
+    (
+        &hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+        b"Hi There",
+        hex!("b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"),
+    ),
+    // TC2 — ASCII key, ASCII data
+    (
+        b"Jefe",
+        b"what do ya want for nothing?",
+        hex!("5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"),
+    ),
+    // TC3 — key and data filled with repeated bytes
+    (
+        &hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        &hex!("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+        hex!("773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe"),
+    ),
+    // TC4 — 25-byte key, 50-byte data
+    (
+        &hex!("0102030405060708090a0b0c0d0e0f10111213141516171819"),
+        &hex!("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"),
+        hex!("82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b"),
+    ),
+    // TC6 — key longer than block size (131 bytes), exercises key hashing
+    (
+        &hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        b"Test Using Larger Than Block-Size Key - Hash Key First",
+        hex!("60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"),
+    ),
+    // TC7 — key longer than block size, data longer than block size
+    (
+        &hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        b"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
+        hex!("9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2"),
+    ),
+];
+
+pub fn test_hmac_sha256<Cal: embedded_cal::HmacProvider>(cal: &mut Cal) {
+    use embedded_cal::HmacAlgorithm;
+
+    let hmac_sha256 = Cal::Algorithm::from_cose_number(5i8)
+        .expect("HmacProvider must recognize COSE 5 (HMAC-SHA-256)");
+
+    for (tv_key, tv_data, tv_mac) in HMAC_SHA256 {
+        assert_eq!(
+            cal.hmac(hmac_sha256.clone(), tv_key, tv_data).as_ref(),
+            tv_mac,
+            "HMAC values mismatch"
+        );
+
+        let mut state = cal.init(hmac_sha256.clone(), tv_key);
+        let mid = tv_data.len() / 2;
+        let postmid = mid + 1;
+        if tv_data.len() >= postmid {
+            cal.update(&mut state, &tv_data[..mid]);
+            cal.update(&mut state, &tv_data[mid..postmid]);
+            cal.update(&mut state, &tv_data[postmid..]);
+        } else {
+            cal.update(&mut state, tv_data);
+        }
+        assert_eq!(
+            cal.finalize(state).as_ref(),
+            tv_mac,
+            "HMAC values mismatch when input is fed in chunks"
+        );
+    }
+}
+
 pub fn test_hash_algorithm_sha256<Cal: embedded_cal::HashProvider>(cal: &mut Cal) {
     // Equivalence with other constructors can be handled via
     // embedded_cal::test_hash_algorithm_sha256 (or should we move this in here?)


### PR DESCRIPTION
* add `HmacProvider` and `HmacAlgorithm` traits, mirroring the `HashProvider`/`HashAlgorithm` that we already have
* impl a software HMAC-SHA-256 in the `Extender` built on top of the `HashProvider`
* add some test cases for the [RFC 4231](https://datatracker.ietf.org/doc/html/rfc4231#section-4.2)
* impl the hardware accelerated hmac-sha-256 for stm32