### PR TITLE
Hashes: Require Clone on states

### DIFF
--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -59,6 +59,7 @@ impl Drop for Nrf54l15Cal {
     }
 }
 
+#[derive(Clone)]
 pub struct HashState {
     // We could instead make this unconditional and then set state (in init) to 0x6a, 0x09, 0xe6,
     // 0x67, ... (the big-endian version of the SHA256 starting points 0x6a09e667u32), but the

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -36,6 +36,7 @@ impl embedded_cal::HashAlgorithm for HashAlgorithm {
     }
 }
 
+#[derive(Clone)]
 pub enum HashState {
     Sha256(sha2::Sha256),
 }

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -271,6 +271,25 @@ pub enum HashState<EC: ExtenderConfig> {
     },
 }
 
+impl<EC: ExtenderConfig> Clone for HashState<EC> {
+    // This is the default implemnentation, but we can't derive it because EC is not clone. (We
+    // don't expect it to, but we'd need "minimal derives" in Rust to make it derivable).
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct(arg0) => Self::Direct(arg0.clone()),
+            Self::Sha256 {
+                written,
+                buffer,
+                instance,
+            } => Self::Sha256 {
+                written: *written,
+                buffer: *buffer,
+                instance: instance.clone(),
+            },
+        }
+    }
+}
+
 pub enum HashResult<EC: ExtenderConfig> {
     Sha256([u8; 32]),
     Direct(<EC::Base as HashProvider>::HashResult),

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -117,11 +117,13 @@ pub enum HashAlgorithm {
     Sha256,
 }
 
+#[derive(Clone)]
 pub struct HashState {
     _variant: embedded_cal::plumbing::hash::Sha2ShortVariant,
     context: Option<Context>,
 }
 
+#[derive(Clone)]
 struct Context {
     /// HASH context swap registers (HASH_CSR0 - HASH_CSR53)
     csr: [u32; CSR_REGS_LEN],

--- a/embedded-cal/src/hash.rs
+++ b/embedded-cal/src/hash.rs
@@ -11,7 +11,7 @@ pub trait HashProvider {
     /// way. (Also, if such a hardware actually exists, please open an issue about it).
     // FIXME: Link to stable FAQ position once that is more website/documentation shape and not
     // just a GitHub Markdown document.
-    type HashState: Sized;
+    type HashState: Sized + Clone;
     /// Output of a hashing operation.
     ///
     /// This needs to be sufficiently large to contain any selected hash's output. When collecting

--- a/embedded-cal/src/plumbing/hash/sha2short.rs
+++ b/embedded-cal/src/plumbing/hash/sha2short.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum Sha2ShortVariant {
     Sha244,
     Sha256,
@@ -32,7 +32,7 @@ pub trait Sha2Short {
     /// State containing an ongoing operation.
     ///
     /// Analogous to [`crate::HashProvider::HashState`].
-    type State: Sized;
+    type State: Sized + Clone;
 
     /// Initiates a [`Self::State`] according to the selected algorithm.
     fn init(&mut self, variant: Sha2ShortVariant) -> Self::State;


### PR DESCRIPTION
This is no absolute requirement for implementing key items for HMAC (item 1 of https://github.com/lake-rs/embedded-cal/issues/42), but simplifies it.

The main review question is whether that is an operation we *want* to expect. (People could still expect it *locally*, eg. by requiring that the associated type be Clone). It is typically provided, but is that common enough to be universal?