### PR TITLE
HMAC: Introduce key type

### DIFF
--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -99,11 +99,16 @@ impl embedded_cal::HashProvider for Nrf54l15Cal {
 
 impl embedded_cal::HmacProvider for Nrf54l15Cal {
     type Algorithm = embedded_cal::NoHmacAlgorithms;
+    type Key = embedded_cal::NoHmacAlgorithms;
     type HmacState = embedded_cal::NoHmacAlgorithms;
     type HmacResult = embedded_cal::NoHmacAlgorithms;
 
-    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match algorithm {}
+    }
+
+    fn init(&mut self, key: Self::Key) -> Self::HmacState {
+        key
     }
 
     fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -59,6 +59,7 @@ impl Drop for Nrf54l15Cal {
     }
 }
 
+#[derive(Clone)]
 pub struct HashState {
     // We could instead make this unconditional and then set state (in init) to 0x6a, 0x09, 0xe6,
     // 0x67, ... (the big-endian version of the SHA256 starting points 0x6a09e667u32), but the

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -102,7 +102,7 @@ impl embedded_cal::HmacProvider for Nrf54l15Cal {
     type HmacState = embedded_cal::NoHmacAlgorithms;
     type HmacResult = embedded_cal::NoHmacAlgorithms;
 
-    fn init(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
         match algorithm {}
     }
 

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -36,6 +36,7 @@ impl embedded_cal::HashAlgorithm for HashAlgorithm {
     }
 }
 
+#[derive(Clone)]
 pub enum HashState {
     Sha256(sha2::Sha256),
 }

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -326,6 +326,29 @@ impl embedded_cal::HmacAlgorithm for HmacAlgorithm {
     }
 }
 
+pub enum HmacKey<EC: ExtenderConfig> {
+    // This is exactly as HmacState to the point where the HmacKey associated type could also be
+    // HmacState -- but that would incur a Clone requirement (and a Clone guarantee on HmacState)
+    // that we can't keep up when we forward to the underlying implementation.
+    HmacSha256 {
+        inner: HashState<EC>,
+        outer_key: [u8; SHA2SHORT_BLOCK_SIZE],
+    },
+}
+
+impl<EC: ExtenderConfig> Clone for HmacKey<EC> {
+    // This is the default implemnentation, but we can't derive it because EC is not clone. (We
+    // don't expect it to, but we'd need "minimal derives" in Rust to make it derivable).
+    fn clone(&self) -> Self {
+        match self {
+            Self::HmacSha256 { inner, outer_key } => Self::HmacSha256 {
+                inner: inner.clone(),
+                outer_key: outer_key.clone(),
+            },
+        }
+    }
+}
+
 pub enum HmacState<EC: ExtenderConfig> {
     HmacSha256 {
         /// Inner hash state accumulating `H((K XOR ipad) || message)`.
@@ -349,10 +372,11 @@ impl AsRef<[u8]> for HmacResult {
 
 impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
     type Algorithm = HmacAlgorithm;
+    type Key = HmacKey<EC>;
     type HmacState = HmacState<EC>;
     type HmacResult = HmacResult;
 
-    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
         match algorithm {
             HmacAlgorithm::HmacSha256 => {
                 // Normalise key to exactly SHA2SHORT_BLOCK_SIZE bytes.
@@ -383,8 +407,14 @@ impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
                 let mut inner = HashProvider::init(self, HashAlgorithm::Sha256);
                 HashProvider::update(self, &mut inner, &ipad_block);
 
-                HmacState::HmacSha256 { inner, outer_key }
+                HmacKey::HmacSha256 { inner, outer_key }
             }
+        }
+    }
+
+    fn init(&mut self, key: Self::Key) -> Self::HmacState {
+        match key {
+            HmacKey::HmacSha256 { inner, outer_key } => HmacState::HmacSha256 { inner, outer_key }
         }
     }
 

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -271,6 +271,25 @@ pub enum HashState<EC: ExtenderConfig> {
     },
 }
 
+impl<EC: ExtenderConfig> Clone for HashState<EC> {
+    // This is the default implemnentation, but we can't derive it because EC is not clone. (We
+    // don't expect it to, but we'd need "minimal derives" in Rust to make it derivable).
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct(arg0) => Self::Direct(arg0.clone()),
+            Self::Sha256 {
+                written,
+                buffer,
+                instance,
+            } => Self::Sha256 {
+                written: *written,
+                buffer: *buffer,
+                instance: instance.clone(),
+            },
+        }
+    }
+}
+
 pub enum HashResult<EC: ExtenderConfig> {
     Sha256([u8; 32]),
     Direct(<EC::Base as HashProvider>::HashResult),

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -352,7 +352,7 @@ impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
     type HmacState = HmacState<EC>;
     type HmacResult = HmacResult;
 
-    fn init(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
         match algorithm {
             HmacAlgorithm::HmacSha256 => {
                 // Normalise key to exactly SHA2SHORT_BLOCK_SIZE bytes.

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -45,7 +45,7 @@ impl embedded_cal::HmacProvider for DummySha256 {
     type HmacState = embedded_cal::NoHmacAlgorithms;
     type HmacResult = embedded_cal::NoHmacAlgorithms;
 
-    fn init(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
         match algorithm {}
     }
 

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -173,6 +173,7 @@ impl embedded_cal::HmacAlgorithm for HmacAlgorithm {
 }
 
 /// State for an in-progress HMAC-SHA256 operation.
+#[derive(Clone)]
 pub struct HmacState {
     /// Saved HASH hardware context (captured after each block written to hardware).
     context: Option<Context>,
@@ -196,10 +197,11 @@ impl AsRef<[u8]> for HmacResult {
 
 impl embedded_cal::HmacProvider for Stm32wba55Cal {
     type Algorithm = HmacAlgorithm;
+    type Key = HmacState;
     type HmacState = HmacState;
     type HmacResult = HmacResult;
 
-    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
         match algorithm {
             HmacAlgorithm::HmacSha256 => {
                 // Normalise key: zero-pad short keys; hash long keys per RFC 2104.
@@ -243,6 +245,10 @@ impl embedded_cal::HmacProvider for Stm32wba55Cal {
                 }
             }
         }
+    }
+
+    fn init(&mut self, key: Self::Key) -> Self::HmacState {
+        key
     }
 
     fn update(&mut self, state: &mut Self::HmacState, data: &[u8]) {

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -117,11 +117,13 @@ pub enum HashAlgorithm {
     Sha256,
 }
 
+#[derive(Clone)]
 pub struct HashState {
     _variant: embedded_cal::plumbing::hash::Sha2ShortVariant,
     context: Option<Context>,
 }
 
+#[derive(Clone)]
 struct Context {
     /// HASH context swap registers (HASH_CSR0 - HASH_CSR53)
     csr: [u32; CSR_REGS_LEN],

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -199,7 +199,7 @@ impl embedded_cal::HmacProvider for Stm32wba55Cal {
     type HmacState = HmacState;
     type HmacResult = HmacResult;
 
-    fn init(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
         match algorithm {
             HmacAlgorithm::HmacSha256 => {
                 // Normalise key: zero-pad short keys; hash long keys per RFC 2104.

--- a/embedded-cal/src/hash.rs
+++ b/embedded-cal/src/hash.rs
@@ -11,7 +11,7 @@ pub trait HashProvider {
     /// way. (Also, if such a hardware actually exists, please open an issue about it).
     // FIXME: Link to stable FAQ position once that is more website/documentation shape and not
     // just a GitHub Markdown document.
-    type HashState: Sized;
+    type HashState: Sized + Clone;
     /// Output of a hashing operation.
     ///
     /// This needs to be sufficiently large to contain any selected hash's output. When collecting

--- a/embedded-cal/src/hmac.rs
+++ b/embedded-cal/src/hmac.rs
@@ -9,8 +9,12 @@ pub trait HmacProvider {
     fn update(&mut self, state: &mut Self::HmacState, data: &[u8]);
     fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult;
 
-    /// Compute HMAC over contiguous in-memory data in a single pass.
-    fn hmac(&mut self, algorithm: Self::Algorithm, key: &[u8], data: &[u8]) -> Self::HmacResult {
+    /// Compute HMAC over contiguous in-memory data in a single pass, based on a key directly
+    /// entered as bytes.
+    ///
+    /// This is a shortcut for [`self.init_with_keydata(…)`] / [`self.update(…)`] /
+    /// [`self.finalize(…)`].
+    fn hmac_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8], data: &[u8]) -> Self::HmacResult {
         let mut state = self.init_with_keydata(algorithm, key);
         self.update(&mut state, data);
         self.finalize(state)

--- a/embedded-cal/src/hmac.rs
+++ b/embedded-cal/src/hmac.rs
@@ -1,11 +1,23 @@
 pub trait HmacProvider {
     type Algorithm: HmacAlgorithm;
+    /// A nascent state that .
+    type Key: Clone + Sized;
     /// State carried between rounds of feeding data into the HMAC.
     type HmacState: Sized;
     /// Output of an HMAC operation.
     type HmacResult: AsRef<[u8]>;
 
-    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState;
+    /// Starts an HMAC operation based on a key that is entered as raw bytes.
+    ///
+    /// This is a convenience wrapper for `Self::init(Self::load_from_keydatra(algorithm, key))`.
+    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState {
+        let key = self.load_from_keydata(algorithm, key);
+        self.init(key)
+    }
+    /// Initializes a key from raw bytes.
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key;
+    /// Starts an HMAC operation.
+    fn init(&mut self, key: Self::Key) -> Self::HmacState;
     fn update(&mut self, state: &mut Self::HmacState, data: &[u8]);
     fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult;
 
@@ -14,7 +26,12 @@ pub trait HmacProvider {
     ///
     /// This is a shortcut for [`self.init_with_keydata(…)`] / [`self.update(…)`] /
     /// [`self.finalize(…)`].
-    fn hmac_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8], data: &[u8]) -> Self::HmacResult {
+    fn hmac_with_keydata(
+        &mut self,
+        algorithm: Self::Algorithm,
+        key: &[u8],
+        data: &[u8],
+    ) -> Self::HmacResult {
         let mut state = self.init_with_keydata(algorithm, key);
         self.update(&mut state, data);
         self.finalize(state)

--- a/embedded-cal/src/hmac.rs
+++ b/embedded-cal/src/hmac.rs
@@ -5,13 +5,13 @@ pub trait HmacProvider {
     /// Output of an HMAC operation.
     type HmacResult: AsRef<[u8]>;
 
-    fn init(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState;
+    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::HmacState;
     fn update(&mut self, state: &mut Self::HmacState, data: &[u8]);
     fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult;
 
     /// Compute HMAC over contiguous in-memory data in a single pass.
     fn hmac(&mut self, algorithm: Self::Algorithm, key: &[u8], data: &[u8]) -> Self::HmacResult {
-        let mut state = self.init(algorithm, key);
+        let mut state = self.init_with_keydata(algorithm, key);
         self.update(&mut state, data);
         self.finalize(state)
     }

--- a/embedded-cal/src/plumbing/hash/sha2short.rs
+++ b/embedded-cal/src/plumbing/hash/sha2short.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum Sha2ShortVariant {
     Sha244,
     Sha256,
@@ -32,7 +32,7 @@ pub trait Sha2Short {
     /// State containing an ongoing operation.
     ///
     /// Analogous to [`crate::HashProvider::HashState`].
-    type State: Sized;
+    type State: Sized + Clone;
 
     /// Initiates a [`Self::State`] according to the selected algorithm.
     fn init(&mut self, variant: Sha2ShortVariant) -> Self::State;

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -94,7 +94,7 @@ pub fn test_hmac_sha256<Cal: embedded_cal::HmacProvider>(cal: &mut Cal) {
 
     for (tv_key, tv_data, tv_mac) in HMAC_SHA256 {
         assert_eq!(
-            cal.hmac(hmac_sha256.clone(), tv_key, tv_data).as_ref(),
+            cal.hmac_with_keydata(hmac_sha256.clone(), tv_key, tv_data).as_ref(),
             tv_mac,
             "HMAC values mismatch"
         );

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -94,7 +94,8 @@ pub fn test_hmac_sha256<Cal: embedded_cal::HmacProvider>(cal: &mut Cal) {
 
     for (tv_key, tv_data, tv_mac) in HMAC_SHA256 {
         assert_eq!(
-            cal.hmac_with_keydata(hmac_sha256.clone(), tv_key, tv_data).as_ref(),
+            cal.hmac_with_keydata(hmac_sha256.clone(), tv_key, tv_data)
+                .as_ref(),
             tv_mac,
             "HMAC values mismatch"
         );

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -99,7 +99,7 @@ pub fn test_hmac_sha256<Cal: embedded_cal::HmacProvider>(cal: &mut Cal) {
             "HMAC values mismatch"
         );
 
-        let mut state = cal.init(hmac_sha256.clone(), tv_key);
+        let mut state = cal.init_with_keydata(hmac_sha256.clone(), tv_key);
         let mid = tv_data.len() / 2;
         let postmid = mid + 1;
         if tv_data.len() >= postmid {


### PR DESCRIPTION
This follows up on item 1 of https://github.com/lake-rs/embedded-cal/issues/42: have a dedicated type, so that encapsulated keys can be used.

It builds on https://github.com/lake-rs/embedded-cal/pull/43, but could be done differently too (it was just easier this way).

It is not completely without alternative: We *could* also decide that any key material that gets taken from elsewhere becomes a HmacState that happens to be otherwise un-updated -- but I think the intention of the APIs is clearer with a dedicated type, the hardware impls show that it is easy to do, and it also allows for some more optimizations (eg. because keys might be kept around in memory between operations, and thus don't need to carry a buffer, even though the current impls happen to do that).