### PR TITLE
Clean up after missing CI checks

### DIFF
--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -414,7 +414,7 @@ impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
 
     fn init(&mut self, key: Self::Key) -> Self::HmacState {
         match key {
-            HmacKey::HmacSha256 { inner, outer_key } => HmacState::HmacSha256 { inner, outer_key }
+            HmacKey::HmacSha256 { inner, outer_key } => HmacState::HmacSha256 { inner, outer_key },
         }
     }
 

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -343,7 +343,7 @@ impl<EC: ExtenderConfig> Clone for HmacKey<EC> {
         match self {
             Self::HmacSha256 { inner, outer_key } => Self::HmacSha256 {
                 inner: inner.clone(),
-                outer_key: outer_key.clone(),
+                outer_key: *outer_key,
             },
         }
     }

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -42,11 +42,16 @@ impl embedded_cal::HashProvider for DummySha256 {
 
 impl embedded_cal::HmacProvider for DummySha256 {
     type Algorithm = embedded_cal::NoHmacAlgorithms;
+    type Key = embedded_cal::NoHmacAlgorithms;
     type HmacState = embedded_cal::NoHmacAlgorithms;
     type HmacResult = embedded_cal::NoHmacAlgorithms;
 
-    fn init_with_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::HmacState {
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
         match algorithm {}
+    }
+
+    fn init(&mut self, key: Self::Key) -> Self::HmacState {
+        match key {}
     }
 
     fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {

--- a/embedded-cal/src/hmac.rs
+++ b/embedded-cal/src/hmac.rs
@@ -24,8 +24,8 @@ pub trait HmacProvider {
     /// Compute HMAC over contiguous in-memory data in a single pass, based on a key directly
     /// entered as bytes.
     ///
-    /// This is a shortcut for [`self.init_with_keydata(…)`] / [`self.update(…)`] /
-    /// [`self.finalize(…)`].
+    /// This is a shortcut for [`self.init_with_keydata(…)`][Self::init_with_keydata()] /
+    /// [`self.update(…)`][Self::update()] / [`self.finalize(…)`][Self::finalize()].
     fn hmac_with_keydata(
         &mut self,
         algorithm: Self::Algorithm,


### PR DESCRIPTION
Something went wrong merging https://github.com/lake-rs/embedded-cal/pull/44 and a formatting error [edit: and a clippy warning and more] slipped through -- more precisely, that's because no branch protection rule enforces that the tests pass, and the visual checks tend to get ignored while F* export is still not working.