### PR TITLE
Enable AEAD in Cal

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: run `cargo clippy`
       run: cargo clippy --workspace -- --deny clippy::all
     - name: run `cargo doc`
-      run: RUSTDOCFLAGS="-D warnings" cargo doc
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
     - name: run `cargo test`
       run: cargo test
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Check if code is well formatted
       run: cargo fmt --check
     - name: run `cargo check`
-      run: RUSTFLAGS="-D warnings" cargo check
+      run: RUSTFLAGS="-D warnings" cargo check --workspace
     - name: run `cargo clippy`
       run: cargo clippy --workspace -- --deny clippy::all
     - name: run `cargo doc`

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -1,0 +1,35 @@
+// FIXME: Something is probably there, just not implemented yet.
+//
+// (This would be more concise
+// <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
+
+impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
+    type Algorithm = embedded_cal::NoAeadAlgorithms;
+    type Key = embedded_cal::NoAeadAlgorithms;
+    type Tag = embedded_cal::NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match *key {}
+    }
+}

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+mod aead;
 mod descriptor;
 mod try_rng;
 

--- a/embedded-cal-software/src/aead.rs
+++ b/embedded-cal-software/src/aead.rs
@@ -1,0 +1,35 @@
+use embedded_cal::AeadProvider;
+
+use super::{Extender, ExtenderConfig};
+
+/// Right now, this is just forwarding, as there is no plumbing yet to build on.
+impl<EC: ExtenderConfig> AeadProvider for Extender<EC> {
+    type Algorithm = <EC::Base as AeadProvider>::Algorithm;
+    type Key = <EC::Base as AeadProvider>::Key;
+    type Tag = <EC::Base as AeadProvider>::Tag;
+
+    fn load_from_keydata(&mut self, _alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        todo!()
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        _key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        todo!()
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        _key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        todo!()
+    }
+}

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -6,6 +6,7 @@
 
 use embedded_cal::{Cal, plumbing::Plumbing};
 
+mod aead;
 mod hash;
 mod hmac;
 mod rng;

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -4,7 +4,7 @@
 //! only does the hard work of the SHA hashes and not the clerical buffering / padding.
 #![no_std]
 
-use embedded_cal::{HashProvider, plumbing::Plumbing};
+use embedded_cal::{Cal, plumbing::Plumbing};
 
 mod hash;
 mod hmac;
@@ -13,7 +13,7 @@ mod rng;
 pub trait ExtenderConfig {
     const IMPLEMENT_SHA2SHORT: bool;
 
-    type Base: HashProvider + Plumbing;
+    type Base: Cal + Plumbing;
 }
 
 impl<EC: ExtenderConfig> Extender<EC> {

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -24,6 +24,8 @@ const k: [u32; 64] = [
     0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
 ];
 
+impl embedded_cal::Cal for DummySha256 {}
+
 impl embedded_cal::plumbing::Plumbing for DummySha256 {}
 
 impl embedded_cal::plumbing::hash::Hash for DummySha256 {}

--- a/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
@@ -45,3 +45,34 @@ impl embedded_cal::HmacProvider for DummySha256 {
         match state {}
     }
 }
+
+impl embedded_cal::AeadProvider for DummySha256 {
+    type Algorithm = embedded_cal::NoAeadAlgorithms;
+    type Key = embedded_cal::NoAeadAlgorithms;
+    type Tag = embedded_cal::NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match *key {}
+    }
+}

--- a/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
@@ -29,7 +29,7 @@ impl embedded_cal::HmacProvider for DummySha256 {
     type HmacState = embedded_cal::NoHmacAlgorithms;
     type HmacResult = embedded_cal::NoHmacAlgorithms;
 
-    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match algorithm {}
     }
 

--- a/embedded-cal-stm32wba55/src/aead.rs
+++ b/embedded-cal-stm32wba55/src/aead.rs
@@ -1,0 +1,35 @@
+// FIXME: Something is probably there, just not implemented yet.
+//
+// (This would be more concise
+// <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
+
+impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
+    type Algorithm = embedded_cal::NoAeadAlgorithms;
+    type Key = embedded_cal::NoAeadAlgorithms;
+    type Tag = embedded_cal::NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match *key {}
+    }
+}

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -9,6 +9,7 @@ use stm32_metapac::{
         vals::{Clkdiv, Htcfg, Nistc, RngConfig1, RngConfig2, RngConfig3},
     },
 };
+mod aead;
 mod try_rng;
 
 const WORD_SIZE: usize = 4;

--- a/embedded-cal/src/aead.rs
+++ b/embedded-cal/src/aead.rs
@@ -115,6 +115,26 @@ pub trait AeadAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum NoAeadAlgorithms {}
 
+impl AeadAlgorithm for NoAeadAlgorithms {
+    fn key_length(&self) -> usize {
+        match *self {}
+    }
+
+    fn tag_length(&self) -> usize {
+        match *self {}
+    }
+
+    fn nonce_length(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl AsRef<[u8]> for NoAeadAlgorithms {
+    fn as_ref(&self) -> &[u8] {
+        match *self {}
+    }
+}
+
 /// Tool for providing the AAD (Additional Authenticated Data) in a scatter-gather fashion.
 pub trait AadGenerator {
     // FIXME: What precise guarantees do we want to ask/give?

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -15,4 +15,4 @@ pub use hash::{HashAlgorithm, HashProvider, NoHashAlgorithms, test_hash_algorith
 pub use hmac::{HmacAlgorithm, HmacProvider, NoHmacAlgorithms, test_hmac_algorithm_hmacsha256};
 pub use rng::test_tryrng;
 
-pub trait Cal: HashProvider + HmacProvider {}
+pub trait Cal: HashProvider + HmacProvider + AeadProvider {}


### PR DESCRIPTION
In https://github.com/lake-rs/embedded-cal/pull/45 I missed making AeadProvider a mandatory Cal interface, and thus a bit of fall-out.

As this would have pushed the software implementation parts over the limit of being manageable, it is blocked by #48 (on which it builds).