### PR TITLE
Provide empty implementation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: run `cargo clippy`
       run: cargo clippy --workspace -- --deny clippy::all
     - name: run `cargo doc`
-      run: RUSTDOCFLAGS="-D warnings" cargo doc
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
     - name: run `cargo test`
       run: cargo test
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Check if code is well formatted
       run: cargo fmt --check
     - name: run `cargo check`
-      run: RUSTFLAGS="-D warnings" cargo check
+      run: RUSTFLAGS="-D warnings" cargo check --workspace
     - name: run `cargo clippy`
       run: cargo clippy --workspace -- --deny clippy::all
     - name: run `cargo doc`

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -4,9 +4,9 @@
 // <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
 
 impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
-    type Algorithm = embedded_cal::NoAeadAlgorithms;
-    type Key = embedded_cal::NoAeadAlgorithms;
-    type Tag = embedded_cal::NoAeadAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type Key = embedded_cal::empty::NoAlgorithms;
+    type Tag = embedded_cal::empty::NoAlgorithms;
 
     fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match alg {}

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -1,0 +1,35 @@
+// FIXME: Something is probably there, just not implemented yet.
+//
+// (This would be more concise
+// <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
+
+impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
+    type Algorithm = embedded_cal::NoAeadAlgorithms;
+    type Key = embedded_cal::NoAeadAlgorithms;
+    type Tag = embedded_cal::NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match *key {}
+    }
+}

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -81,9 +81,9 @@ impl AsRef<[u8]> for HashResult {
 }
 
 impl embedded_cal::HashProvider for Nrf54l15Cal {
-    type Algorithm = embedded_cal::NoHashAlgorithms;
-    type HashState = embedded_cal::NoHashAlgorithms;
-    type HashResult = embedded_cal::NoHashAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type HashState = embedded_cal::empty::NoAlgorithms;
+    type HashResult = embedded_cal::empty::NoAlgorithms;
 
     fn init(&mut self, algorithm: Self::Algorithm) -> Self::HashState {
         match algorithm {}
@@ -99,10 +99,10 @@ impl embedded_cal::HashProvider for Nrf54l15Cal {
 }
 
 impl embedded_cal::HmacProvider for Nrf54l15Cal {
-    type Algorithm = embedded_cal::NoHmacAlgorithms;
-    type Key = embedded_cal::NoHmacAlgorithms;
-    type HmacState = embedded_cal::NoHmacAlgorithms;
-    type HmacResult = embedded_cal::NoHmacAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type Key = embedded_cal::empty::NoAlgorithms;
+    type HmacState = embedded_cal::empty::NoAlgorithms;
+    type HmacResult = embedded_cal::empty::NoAlgorithms;
 
     fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match algorithm {}

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+mod aead;
 mod descriptor;
 mod try_rng;
 

--- a/embedded-cal-software/src/aead.rs
+++ b/embedded-cal-software/src/aead.rs
@@ -1,0 +1,35 @@
+use embedded_cal::AeadProvider;
+
+use super::{Extender, ExtenderConfig};
+
+/// Right now, this is just forwarding, as there is no plumbing yet to build on.
+impl<EC: ExtenderConfig> AeadProvider for Extender<EC> {
+    type Algorithm = <EC::Base as AeadProvider>::Algorithm;
+    type Key = <EC::Base as AeadProvider>::Key;
+    type Tag = <EC::Base as AeadProvider>::Tag;
+
+    fn load_from_keydata(&mut self, _alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        todo!()
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        _key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        todo!()
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        _key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        todo!()
+    }
+}

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -6,6 +6,7 @@
 
 use embedded_cal::{Cal, plumbing::Plumbing};
 
+mod aead;
 mod hash;
 mod hmac;
 mod rng;

--- a/embedded-cal-software/src/lib.rs
+++ b/embedded-cal-software/src/lib.rs
@@ -4,7 +4,7 @@
 //! only does the hard work of the SHA hashes and not the clerical buffering / padding.
 #![no_std]
 
-use embedded_cal::{HashProvider, plumbing::Plumbing};
+use embedded_cal::{Cal, plumbing::Plumbing};
 
 mod hash;
 mod hmac;
@@ -13,7 +13,7 @@ mod rng;
 pub trait ExtenderConfig {
     const IMPLEMENT_SHA2SHORT: bool;
 
-    type Base: HashProvider + Plumbing;
+    type Base: Cal + Plumbing;
 }
 
 impl<EC: ExtenderConfig> Extender<EC> {

--- a/embedded-cal-software/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256.rs
@@ -24,6 +24,8 @@ const k: [u32; 64] = [
     0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
 ];
 
+impl embedded_cal::Cal for DummySha256 {}
+
 impl embedded_cal::plumbing::Plumbing for DummySha256 {}
 
 impl embedded_cal::plumbing::hash::Hash for DummySha256 {}

--- a/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
@@ -45,3 +45,34 @@ impl embedded_cal::HmacProvider for DummySha256 {
         match state {}
     }
 }
+
+impl embedded_cal::AeadProvider for DummySha256 {
+    type Algorithm = embedded_cal::NoAeadAlgorithms;
+    type Key = embedded_cal::NoAeadAlgorithms;
+    type Tag = embedded_cal::NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match *key {}
+    }
+}

--- a/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
@@ -29,7 +29,7 @@ impl embedded_cal::HmacProvider for DummySha256 {
     type HmacState = embedded_cal::NoHmacAlgorithms;
     type HmacResult = embedded_cal::NoHmacAlgorithms;
 
-    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match algorithm {}
     }
 

--- a/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
+++ b/embedded-cal-software/src/tests/dummy_sha256/empty_impls.rs
@@ -6,9 +6,9 @@
 use super::*;
 
 impl embedded_cal::HashProvider for DummySha256 {
-    type Algorithm = embedded_cal::NoHashAlgorithms;
-    type HashState = embedded_cal::NoHashAlgorithms;
-    type HashResult = embedded_cal::NoHashAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type HashState = embedded_cal::empty::NoAlgorithms;
+    type HashResult = embedded_cal::empty::NoAlgorithms;
 
     fn init(&mut self, algorithm: Self::Algorithm) -> Self::HashState {
         match algorithm {}
@@ -24,10 +24,10 @@ impl embedded_cal::HashProvider for DummySha256 {
 }
 
 impl embedded_cal::HmacProvider for DummySha256 {
-    type Algorithm = embedded_cal::NoHmacAlgorithms;
-    type Key = embedded_cal::NoHmacAlgorithms;
-    type HmacState = embedded_cal::NoHmacAlgorithms;
-    type HmacResult = embedded_cal::NoHmacAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type Key = embedded_cal::empty::NoAlgorithms;
+    type HmacState = embedded_cal::empty::NoAlgorithms;
+    type HmacResult = embedded_cal::empty::NoAlgorithms;
 
     fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match algorithm {}
@@ -47,9 +47,9 @@ impl embedded_cal::HmacProvider for DummySha256 {
 }
 
 impl embedded_cal::AeadProvider for DummySha256 {
-    type Algorithm = embedded_cal::NoAeadAlgorithms;
-    type Key = embedded_cal::NoAeadAlgorithms;
-    type Tag = embedded_cal::NoAeadAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type Key = embedded_cal::empty::NoAlgorithms;
+    type Tag = embedded_cal::empty::NoAlgorithms;
 
     fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match alg {}

--- a/embedded-cal-stm32wba55/src/aead.rs
+++ b/embedded-cal-stm32wba55/src/aead.rs
@@ -4,9 +4,9 @@
 // <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
 
 impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
-    type Algorithm = embedded_cal::NoAeadAlgorithms;
-    type Key = embedded_cal::NoAeadAlgorithms;
-    type Tag = embedded_cal::NoAeadAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type Key = embedded_cal::empty::NoAlgorithms;
+    type Tag = embedded_cal::empty::NoAlgorithms;
 
     fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match alg {}

--- a/embedded-cal-stm32wba55/src/aead.rs
+++ b/embedded-cal-stm32wba55/src/aead.rs
@@ -1,0 +1,35 @@
+// FIXME: Something is probably there, just not implemented yet.
+//
+// (This would be more concise
+// <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
+
+impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
+    type Algorithm = embedded_cal::NoAeadAlgorithms;
+    type Key = embedded_cal::NoAeadAlgorithms;
+    type Tag = embedded_cal::NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match *key {}
+    }
+}

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -135,9 +135,9 @@ struct Context {
 }
 
 impl embedded_cal::HashProvider for Stm32wba55Cal {
-    type Algorithm = embedded_cal::NoHashAlgorithms;
-    type HashState = embedded_cal::NoHashAlgorithms;
-    type HashResult = embedded_cal::NoHashAlgorithms;
+    type Algorithm = embedded_cal::empty::NoAlgorithms;
+    type HashState = embedded_cal::empty::NoAlgorithms;
+    type HashResult = embedded_cal::empty::NoAlgorithms;
 
     fn init(&mut self, algorithm: Self::Algorithm) -> Self::HashState {
         match algorithm {}

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -9,6 +9,7 @@ use stm32_metapac::{
         vals::{Clkdiv, Htcfg, Nistc, RngConfig1, RngConfig2, RngConfig3},
     },
 };
+mod aead;
 mod try_rng;
 
 const WORD_SIZE: usize = 4;

--- a/embedded-cal/src/aead.rs
+++ b/embedded-cal/src/aead.rs
@@ -107,34 +107,6 @@ pub trait AeadAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
     }
 }
 
-/// Type which an implementation of [`Cal`][crate::Cal] can use when it implements no AEAD
-/// algorithm for [`AeadProvider`].
-///
-/// This type is uninhabited and can stand in for all of the [`Algorithm`][AeadProvider::Algorithm]
-/// and [`Tag`][AeadProvider::Tag] associated types.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum NoAeadAlgorithms {}
-
-impl AeadAlgorithm for NoAeadAlgorithms {
-    fn key_length(&self) -> usize {
-        match *self {}
-    }
-
-    fn tag_length(&self) -> usize {
-        match *self {}
-    }
-
-    fn nonce_length(&self) -> usize {
-        match *self {}
-    }
-}
-
-impl AsRef<[u8]> for NoAeadAlgorithms {
-    fn as_ref(&self) -> &[u8] {
-        match *self {}
-    }
-}
-
 /// Tool for providing the AAD (Additional Authenticated Data) in a scatter-gather fashion.
 pub trait AadGenerator {
     // FIXME: What precise guarantees do we want to ask/give?

--- a/embedded-cal/src/aead.rs
+++ b/embedded-cal/src/aead.rs
@@ -115,6 +115,26 @@ pub trait AeadAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum NoAeadAlgorithms {}
 
+impl AeadAlgorithm for NoAeadAlgorithms {
+    fn key_length(&self) -> usize {
+        match *self {}
+    }
+
+    fn tag_length(&self) -> usize {
+        match *self {}
+    }
+
+    fn nonce_length(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl AsRef<[u8]> for NoAeadAlgorithms {
+    fn as_ref(&self) -> &[u8] {
+        match *self {}
+    }
+}
+
 /// Tool for providing the AAD (Additional Authenticated Data) in a scatter-gather fashion.
 pub trait AadGenerator {
     // FIXME: What precise guarantees do we want to ask/give?

--- a/embedded-cal/src/empty.rs
+++ b/embedded-cal/src/empty.rs
@@ -1,0 +1,118 @@
+//! Implementations of the various traits of embedded-cal that implemnt the empty set of
+//! algorithms.
+//!
+//! The types are ZST or uninhabited as suitable for the type.
+
+use super::*;
+
+/// An implementation of [`Cal`] that provides no single algorithm (or, for the random number
+/// aspect that has no algorithms, never succeeds in doing anything).
+pub struct EmptyCal;
+
+impl Cal for EmptyCal {}
+
+// Those should all be shorter when <https://github.com/lake-rs/embedded-cal/issues/40> is
+// resolved; then again, the implementations that do make it short will live here. Until then, feel
+// free to copy those out into your Cal implementations.
+
+impl HashProvider for EmptyCal {
+    type Algorithm = NoHashAlgorithms;
+    type HashState = NoHashAlgorithms;
+    type HashResult = NoHashAlgorithms;
+
+    fn init(&mut self, algorithm: Self::Algorithm) -> Self::HashState {
+        match algorithm {}
+    }
+
+    fn update(&mut self, instance: &mut Self::HashState, _data: &[u8]) {
+        match *instance {}
+    }
+
+    fn finalize(&mut self, instance: Self::HashState) -> Self::HashResult {
+        match instance {}
+    }
+}
+
+impl HmacProvider for EmptyCal {
+    type Algorithm = NoHmacAlgorithms;
+    type Key = NoHmacAlgorithms;
+    type HmacState = NoHmacAlgorithms;
+    type HmacResult = NoHmacAlgorithms;
+
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match algorithm {}
+    }
+
+    fn init(&mut self, key: Self::Key) -> Self::HmacState {
+        match key {}
+    }
+
+    fn update(&mut self, state: &mut Self::HmacState, _data: &[u8]) {
+        match *state {}
+    }
+
+    fn finalize(&mut self, state: Self::HmacState) -> Self::HmacResult {
+        match state {}
+    }
+}
+
+impl AeadProvider for EmptyCal {
+    type Algorithm = NoAeadAlgorithms;
+    type Key = NoAeadAlgorithms;
+    type Tag = NoAeadAlgorithms;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
+        match alg {}
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _aad: impl AadGenerator,
+    ) -> Self::Tag {
+        match *key {}
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        _nonce: &[u8],
+        _message: &mut [u8],
+        _tag: &[u8],
+        _aad: impl AadGenerator,
+    ) -> Result<(), DecryptionFailed> {
+        match *key {}
+    }
+}
+
+impl rand_core::TryCryptoRng for EmptyCal {}
+
+impl rand_core::TryRng for EmptyCal {
+    type Error = NoRng;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Err(NoRng)
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Err(NoRng)
+    }
+
+    fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
+        Err(NoRng)
+    }
+}
+
+/// Error type returned by [`EmtpyCal`] when trying to obtain random numbers.
+#[derive(Debug)]
+pub struct NoRng;
+
+impl core::fmt::Display for NoRng {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("no RNG available in empty Cal implementation")
+    }
+}
+
+impl core::error::Error for NoRng {}

--- a/embedded-cal/src/empty.rs
+++ b/embedded-cal/src/empty.rs
@@ -7,15 +7,15 @@ use super::*;
 
 /// An implementation of [`Cal`] that provides no single algorithm (or, for the random number
 /// aspect that has no algorithms, never succeeds in doing anything).
-pub struct EmptyCal;
+pub struct EmptyCal<const PLUMBING: bool>;
 
-impl Cal for EmptyCal {}
+impl<const PLUMBING: bool> Cal for EmptyCal<PLUMBING> {}
 
 // Those should all be shorter when <https://github.com/lake-rs/embedded-cal/issues/40> is
 // resolved; then again, the implementations that do make it short will live here. Until then, feel
 // free to copy those out into your Cal implementations.
 
-impl HashProvider for EmptyCal {
+impl<const PLUMBING: bool> HashProvider for EmptyCal<PLUMBING> {
     type Algorithm = NoAlgorithms;
     type HashState = NoAlgorithms;
     type HashResult = NoAlgorithms;
@@ -33,7 +33,7 @@ impl HashProvider for EmptyCal {
     }
 }
 
-impl HmacProvider for EmptyCal {
+impl<const PLUMBING: bool> HmacProvider for EmptyCal<PLUMBING> {
     type Algorithm = NoAlgorithms;
     type Key = NoAlgorithms;
     type HmacState = NoAlgorithms;
@@ -56,7 +56,7 @@ impl HmacProvider for EmptyCal {
     }
 }
 
-impl AeadProvider for EmptyCal {
+impl<const PLUMBING: bool> AeadProvider for EmptyCal<PLUMBING> {
     type Algorithm = NoAlgorithms;
     type Key = NoAlgorithms;
     type Tag = NoAlgorithms;
@@ -87,9 +87,9 @@ impl AeadProvider for EmptyCal {
     }
 }
 
-impl rand_core::TryCryptoRng for EmptyCal {}
+impl<const PLUMBING: bool> rand_core::TryCryptoRng for EmptyCal<PLUMBING> {}
 
-impl rand_core::TryRng for EmptyCal {
+impl<const PLUMBING: bool> rand_core::TryRng for EmptyCal<PLUMBING> {
     type Error = NoRng;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
@@ -105,8 +105,33 @@ impl rand_core::TryRng for EmptyCal {
     }
 }
 
-/// Type which an implementation of [`Cal`][crate::Cal] can use when it implements no
-/// algorithm for a particular provider.
+impl plumbing::Plumbing for EmptyCal<true> {}
+
+impl plumbing::hash::Hash for EmptyCal<true> {}
+
+impl plumbing::hash::Sha2Short for EmptyCal<true> {
+    const SUPPORTED: bool = false;
+    const SEND_PADDING: bool = false;
+    const FIRST_CHUNK_SIZE: usize = 0;
+    const UPDATE_MULTICHUNK: bool = false;
+
+    type State = NoAlgorithms;
+
+    fn init(&mut self, _variant: plumbing::hash::Sha2ShortVariant) -> Self::State {
+        panic!("user disregarded SUPPORTED=false")
+    }
+
+    fn update(&mut self, instance: &mut Self::State, _data: &[u8]) {
+        match *instance {}
+    }
+
+    fn finalize(&mut self, instance: Self::State, _last_chunk: &[u8], _target: &mut [u8]) {
+        match instance {}
+    }
+}
+
+/// Type which an implementation of [`Cal`] can use when it implements no algorithm for a
+/// particular provider.
 ///
 /// This type is uninhabited and can stand in for all of the `Algorithm` associated types as well
 /// as state and result types.
@@ -145,7 +170,7 @@ impl AsRef<[u8]> for NoAlgorithms {
     }
 }
 
-/// Error type returned by [`EmtpyCal`] when trying to obtain random numbers.
+/// Error type returned by [`EmptyCal`] when trying to obtain random numbers.
 #[derive(Debug)]
 pub struct NoRng;
 

--- a/embedded-cal/src/empty.rs
+++ b/embedded-cal/src/empty.rs
@@ -16,9 +16,9 @@ impl Cal for EmptyCal {}
 // free to copy those out into your Cal implementations.
 
 impl HashProvider for EmptyCal {
-    type Algorithm = NoHashAlgorithms;
-    type HashState = NoHashAlgorithms;
-    type HashResult = NoHashAlgorithms;
+    type Algorithm = NoAlgorithms;
+    type HashState = NoAlgorithms;
+    type HashResult = NoAlgorithms;
 
     fn init(&mut self, algorithm: Self::Algorithm) -> Self::HashState {
         match algorithm {}
@@ -34,10 +34,10 @@ impl HashProvider for EmptyCal {
 }
 
 impl HmacProvider for EmptyCal {
-    type Algorithm = NoHmacAlgorithms;
-    type Key = NoHmacAlgorithms;
-    type HmacState = NoHmacAlgorithms;
-    type HmacResult = NoHmacAlgorithms;
+    type Algorithm = NoAlgorithms;
+    type Key = NoAlgorithms;
+    type HmacState = NoAlgorithms;
+    type HmacResult = NoAlgorithms;
 
     fn load_from_keydata(&mut self, algorithm: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match algorithm {}
@@ -57,9 +57,9 @@ impl HmacProvider for EmptyCal {
 }
 
 impl AeadProvider for EmptyCal {
-    type Algorithm = NoAeadAlgorithms;
-    type Key = NoAeadAlgorithms;
-    type Tag = NoAeadAlgorithms;
+    type Algorithm = NoAlgorithms;
+    type Key = NoAlgorithms;
+    type Tag = NoAlgorithms;
 
     fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
         match alg {}
@@ -102,6 +102,46 @@ impl rand_core::TryRng for EmptyCal {
 
     fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
         Err(NoRng)
+    }
+}
+
+/// Type which an implementation of [`Cal`][crate::Cal] can use when it implements no
+/// algorithm for a particular provider.
+///
+/// This type is uninhabited and can stand in for all of the `Algorithm` associated types as well
+/// as state and result types.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum NoAlgorithms {}
+
+impl AeadAlgorithm for NoAlgorithms {
+    fn key_length(&self) -> usize {
+        match *self {}
+    }
+
+    fn tag_length(&self) -> usize {
+        match *self {}
+    }
+
+    fn nonce_length(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl HashAlgorithm for NoAlgorithms {
+    fn len(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl HmacAlgorithm for NoAlgorithms {
+    fn len(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl AsRef<[u8]> for NoAlgorithms {
+    fn as_ref(&self) -> &[u8] {
+        match *self {}
     }
 }
 

--- a/embedded-cal/src/hash.rs
+++ b/embedded-cal/src/hash.rs
@@ -109,26 +109,6 @@ pub trait HashAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
     }
 }
 
-/// Type which an implemnetation of [`Cal`][crate::Cal] can use when it implements no single
-/// algorithm for [`HashProvider`].
-///
-/// This type is uninhabited and can stand in for all of the [`Algorithm`][HashProvider::Algorithm],
-/// [`HashState`][HashProvider::HashState] and [`HashResult`][HashProvider::HashResult] associated types.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum NoHashAlgorithms {}
-
-impl HashAlgorithm for NoHashAlgorithms {
-    fn len(&self) -> usize {
-        match *self {}
-    }
-}
-
-impl AsRef<[u8]> for NoHashAlgorithms {
-    fn as_ref(&self) -> &[u8] {
-        match *self {}
-    }
-}
-
 // FIXME: Should we introduce a feature to no build those all the time?
 pub fn test_hash_algorithm_sha256<HA: HashAlgorithm>() {
     // FIXME see from_cose_number comment

--- a/embedded-cal/src/hmac.rs
+++ b/embedded-cal/src/hmac.rs
@@ -61,27 +61,6 @@ pub trait HmacAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
     }
 }
 
-/// Type which an implementation of [`Cal`][crate::Cal] can use when it implements no HMAC
-/// algorithm for [`HmacProvider`].
-///
-/// This type is uninhabited and can stand in for all of the [`Algorithm`][HmacProvider::Algorithm],
-/// [`HmacState`][HmacProvider::HmacState] and [`HmacResult`][HmacProvider::HmacResult] associated
-/// types.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum NoHmacAlgorithms {}
-
-impl HmacAlgorithm for NoHmacAlgorithms {
-    fn len(&self) -> usize {
-        match *self {}
-    }
-}
-
-impl AsRef<[u8]> for NoHmacAlgorithms {
-    fn as_ref(&self) -> &[u8] {
-        match *self {}
-    }
-}
-
 pub fn test_hmac_algorithm_hmacsha256<HA: HmacAlgorithm>() {
     let cose_5 = HA::from_cose_number(5i8);
     assert!(

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+pub mod empty;
+
 mod aead;
 mod hash;
 mod hmac;

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -15,4 +15,4 @@ pub use hash::{HashAlgorithm, HashProvider, NoHashAlgorithms, test_hash_algorith
 pub use hmac::{HmacAlgorithm, HmacProvider, NoHmacAlgorithms, test_hmac_algorithm_hmacsha256};
 pub use rng::test_tryrng;
 
-pub trait Cal: HashProvider + HmacProvider {}
+pub trait Cal: HashProvider + HmacProvider + AeadProvider {}

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -10,11 +10,11 @@ mod rng;
 pub mod plumbing;
 
 pub use aead::{
-    AadGenerator, AeadAlgorithm, AeadProvider, DecryptionFailed, NoAeadAlgorithms,
+    AadGenerator, AeadAlgorithm, AeadProvider, DecryptionFailed,
     test_aead_algorithm_aesccm_16_64_128,
 };
-pub use hash::{HashAlgorithm, HashProvider, NoHashAlgorithms, test_hash_algorithm_sha256};
-pub use hmac::{HmacAlgorithm, HmacProvider, NoHmacAlgorithms, test_hmac_algorithm_hmacsha256};
+pub use hash::{HashAlgorithm, HashProvider, test_hash_algorithm_sha256};
+pub use hmac::{HmacAlgorithm, HmacProvider, test_hmac_algorithm_hmacsha256};
 pub use rng::test_tryrng;
 
 pub trait Cal: HashProvider + HmacProvider + AeadProvider {}


### PR DESCRIPTION
This is based on #49, so only the top <del>2</del> 3 [edit: after actually passing CI and updating the libcrux use case to use all this] commits are relevant here.

This provides an implementation that is completely empty, parts of which are suitable for copy-pasting into all the impls that just provide a few and not all items.

As part of this, all the duplicate No…Algorithms uninhabited items are unified into a single type, reducing repetition.