### PR TITLE
Add libcrux implementation for AES-GCM (without hardware acceleration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,8 +20,14 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -49,6 +55,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -84,6 +96,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +114,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "core-models"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c406a8d3cdec6393dc8975b623d806ce2d586653c620f86f7fab2e043df1cb2"
+dependencies = [
+ "hax-lib 0.3.6",
+ "pastey",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -145,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +218,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "defmt-macros",
 ]
 
@@ -257,6 +300,7 @@ name = "embedded-cal-libcrux"
 version = "0.1.0"
 dependencies = [
  "embedded-cal",
+ "libcrux-aesgcm",
  "libcrux-sha2",
  "testvectors",
 ]
@@ -327,6 +371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,9 +400,38 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hax-lib"
@@ -420,10 +505,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hexlit"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6e75c860d4216ac53f9ac88b25c99eaedba075b3a7b2ed31f2adc51a74fffd"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "inout"
@@ -451,10 +560,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libcrux-aesgcm"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b934645bf352ac97dcd15d3320d112fb666e0d6e36d43f775fd56f798d8076ef"
+dependencies = [
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-traits 0.0.7",
+]
 
 [[package]]
 name = "libcrux-hacl-rs"
@@ -466,6 +593,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcrux-intrinsics"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b254f1797aecd888f76e9647e6bec7b4c26fb6d60a73fd9856e4a1e535c704"
+dependencies = [
+ "core-models",
+ "hax-lib 0.3.6",
+]
+
+[[package]]
 name = "libcrux-macros"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +610,15 @@ checksum = "ffd6aa2dcd5be681662001b81d493f1569c6d49a32361f470b0c955465cd0338"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -492,7 +638,7 @@ checksum = "e9d253473f259fc74a280c43f29c464f7e374abdf28b4942234dc707f529d4b7"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-traits",
+ "libcrux-traits 0.0.6",
 ]
 
 [[package]]
@@ -502,7 +648,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
 dependencies = [
  "libcrux-secrets",
- "rand",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2613bf3dbf3670777bd6ecc3bcdd2d7a642663656b35ed2823529c4f1db0c9e9"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -587,6 +743,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,12 +805,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -659,7 +848,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -682,6 +871,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "semver-parser"
@@ -739,7 +934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -811,12 +1006,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -863,7 +1064,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -926,7 +1136,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver 1.0.28",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "embedded-cal",
  "libcrux-aesgcm",
  "libcrux-sha2",
+ "libcrux-traits 0.0.7",
  "testvectors",
 ]
 

--- a/embedded-cal-libcrux/Cargo.toml
+++ b/embedded-cal-libcrux/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 embedded-cal.path = "../embedded-cal"
 libcrux-sha2 = "0.0.6"
 libcrux-aesgcm = "0.0.8"
+libcrux-traits = { version = "0.0.7", features = ["error-in-core"] }
 
 [dev-dependencies]
 testvectors.path = "../testvectors"

--- a/embedded-cal-libcrux/Cargo.toml
+++ b/embedded-cal-libcrux/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [dependencies]
 embedded-cal.path = "../embedded-cal"
 libcrux-sha2 = "0.0.6"
+libcrux-aesgcm = "0.0.8"
 
 [dev-dependencies]
 testvectors.path = "../testvectors"

--- a/embedded-cal-libcrux/src/aead.rs
+++ b/embedded-cal-libcrux/src/aead.rs
@@ -1,8 +1,13 @@
-use libcrux_aesgcm::AeadConsts;
+use libcrux_aesgcm::AeadConsts as _;
+use libcrux_traits::aead::typed_owned;
 
 use embedded_cal::AeadProvider;
 
 use super::*;
+
+// Used to copy the ciphertext out of the way, and to spool the AAD.
+extern crate alloc;
+use alloc::{vec, vec::Vec};
 
 pub enum AeadAlgorithm<EC: ExtenderConfig> {
     Direct(<EC::Base as AeadProvider>::Algorithm),
@@ -50,11 +55,63 @@ impl<EC: ExtenderConfig> embedded_cal::AeadProvider for Extender<EC> {
         message: &mut [u8],
         aad: impl embedded_cal::AadGenerator,
     ) -> Self::Tag {
-        match key {
-            Key::Direct(k) => Tag::Direct(self.0.encrypt_in_place(k, nonce, message, aad)),
-            Key::AesGcm128(key) => todo!(),
-            Key::AesGcm256(key) => todo!(),
+        // Handle the simple case quicly; everything else needs the allocations
+        if let Key::Direct(k) = key {
+            return Tag::Direct(self.0.encrypt_in_place(k, nonce, message, aad));
+        };
+
+        let mut ciphertext = vec![0; message.len()];
+        let aad: Vec<_> = aad.items().flatten().copied().collect();
+
+        // I hope this explicitness mess pays off when we run not 2 but many types through
+        // the match below.
+
+        fn encrypt<Alg, const T: usize, const N: usize>(
+            ciphertext: &mut Vec<u8>,
+            key: &typed_owned::Key<Alg>,
+            nonce: &[u8],
+            aad: &Vec<u8>,
+            message: &[u8],
+        ) -> typed_owned::Tag<Alg>
+        where
+            Alg: typed_owned::Aead,
+            typed_owned::Tag<Alg>: From<[u8; T]>,
+            typed_owned::Nonce<Alg>: From<[u8; N]>,
+        {
+            let mut tag: typed_owned::Tag<Alg> = [0u8; _].into();
+            let nonce: typed_owned::Nonce<Alg> =
+                (<[u8; N]>::try_from(nonce).expect("nonce length mismatch")).into();
+            Alg::encrypt(
+                ciphertext.as_mut_slice(),
+                &mut tag,
+                key,
+                &nonce,
+                aad.as_slice(),
+                message,
+            )
+            .expect("slice lenghts match");
+            tag
         }
+
+        let tag = match key {
+            Key::Direct(_) => unreachable!(),
+            Key::AesGcm128(key) => Tag::AesGcm128(encrypt::<libcrux_aesgcm::AesGcm128, _, _>(
+                &mut ciphertext,
+                key,
+                nonce,
+                &aad,
+                message,
+            )),
+            Key::AesGcm256(key) => Tag::AesGcm256(encrypt::<libcrux_aesgcm::AesGcm256, _, _>(
+                &mut ciphertext,
+                key,
+                nonce,
+                &aad,
+                message,
+            )),
+        };
+        message.copy_from_slice(&ciphertext);
+        tag
     }
 
     fn decrypt_in_place(
@@ -65,10 +122,63 @@ impl<EC: ExtenderConfig> embedded_cal::AeadProvider for Extender<EC> {
         tag: &[u8],
         aad: impl embedded_cal::AadGenerator,
     ) -> Result<(), embedded_cal::DecryptionFailed> {
+        // Handle the simple case quicly; everything else needs the allocations
+        if let Key::Direct(k) = key {
+            return self.0.decrypt_in_place(k, nonce, message, tag, aad);
+        };
+
+        let mut ciphertext = Vec::from(&*message);
+        let aad: Vec<_> = aad.items().flatten().copied().collect();
+
+        // I hope this explicitness mess pays off when we run not 2 but many types through
+        // the match below.
+
+        fn decrypt<Alg, const T: usize, const N: usize>(
+            ciphertext: &mut Vec<u8>,
+            key: &typed_owned::Key<Alg>,
+            nonce: &[u8],
+            aad: &Vec<u8>,
+            message: &mut [u8],
+            tag: &[u8],
+        ) -> Result<(), embedded_cal::DecryptionFailed>
+        where
+            Alg: typed_owned::Aead,
+            typed_owned::Tag<Alg>: From<[u8; T]>,
+            typed_owned::Nonce<Alg>: From<[u8; N]>,
+        {
+            let tag: typed_owned::Tag<Alg> =
+                (<[u8; T]>::try_from(tag).expect("tag length mismatch")).into();
+            let nonce: typed_owned::Nonce<Alg> =
+                (<[u8; N]>::try_from(nonce).expect("nonce length mismatch")).into();
+            Alg::decrypt(
+                ciphertext.as_mut_slice(),
+                key,
+                &nonce,
+                aad.as_slice(),
+                message,
+                &tag,
+            )
+            .map_err(|_| embedded_cal::DecryptionFailed)
+        }
+
         match key {
-            Key::Direct(k) => self.0.decrypt_in_place(k, nonce, message, tag, aad),
-            Key::AesGcm128(key) => todo!(),
-            Key::AesGcm256(key) => todo!(),
+            Key::Direct(_) => unreachable!(),
+            Key::AesGcm128(key) => decrypt::<libcrux_aesgcm::AesGcm128, _, _>(
+                &mut ciphertext,
+                key,
+                nonce,
+                &aad,
+                message,
+                tag,
+            ),
+            Key::AesGcm256(key) => decrypt::<libcrux_aesgcm::AesGcm256, _, _>(
+                &mut ciphertext,
+                key,
+                nonce,
+                &aad,
+                message,
+                tag,
+            ),
         }
     }
 }

--- a/embedded-cal-libcrux/src/aead.rs
+++ b/embedded-cal-libcrux/src/aead.rs
@@ -1,0 +1,147 @@
+use libcrux_aesgcm::AeadConsts;
+
+use embedded_cal::AeadProvider;
+
+use super::*;
+
+pub enum AeadAlgorithm<EC: ExtenderConfig> {
+    Direct(<EC::Base as AeadProvider>::Algorithm),
+    AesGcm128,
+    AesGcm256,
+}
+
+pub enum Key<EC: ExtenderConfig> {
+    Direct(<EC::Base as AeadProvider>::Key),
+    AesGcm128(libcrux_aesgcm::AesGcm128Key),
+    AesGcm256(libcrux_aesgcm::AesGcm256Key),
+}
+
+pub enum Tag<EC: ExtenderConfig> {
+    Direct(<EC::Base as AeadProvider>::Tag),
+    AesGcm128(libcrux_aesgcm::AesGcm128Tag),
+    AesGcm256(libcrux_aesgcm::AesGcm256Tag),
+}
+
+impl<EC: ExtenderConfig> embedded_cal::AeadProvider for Extender<EC> {
+    type Algorithm = AeadAlgorithm<EC>;
+    type Key = Key<EC>;
+    type Tag = Tag<EC>;
+
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, key: &[u8]) -> Self::Key {
+        match alg {
+            AeadAlgorithm::Direct(alg) => Key::Direct(self.0.load_from_keydata(alg, key)),
+            AeadAlgorithm::AesGcm128 => Key::AesGcm128(
+                <[u8; _]>::try_from(key)
+                    .expect("key length mismatch")
+                    .into(),
+            ),
+            AeadAlgorithm::AesGcm256 => Key::AesGcm256(
+                <[u8; _]>::try_from(key)
+                    .expect("key length mismatch")
+                    .into(),
+            ),
+        }
+    }
+
+    fn encrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        nonce: &[u8],
+        message: &mut [u8],
+        aad: impl embedded_cal::AadGenerator,
+    ) -> Self::Tag {
+        match key {
+            Key::Direct(k) => Tag::Direct(self.0.encrypt_in_place(k, nonce, message, aad)),
+            Key::AesGcm128(key) => todo!(),
+            Key::AesGcm256(key) => todo!(),
+        }
+    }
+
+    fn decrypt_in_place(
+        &mut self,
+        key: &Self::Key,
+        nonce: &[u8],
+        message: &mut [u8],
+        tag: &[u8],
+        aad: impl embedded_cal::AadGenerator,
+    ) -> Result<(), embedded_cal::DecryptionFailed> {
+        match key {
+            Key::Direct(k) => self.0.decrypt_in_place(k, nonce, message, tag, aad),
+            Key::AesGcm128(key) => todo!(),
+            Key::AesGcm256(key) => todo!(),
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> embedded_cal::AeadAlgorithm for AeadAlgorithm<EC> {
+    fn key_length(&self) -> usize {
+        match self {
+            AeadAlgorithm::Direct(a) => a.key_length(),
+            AeadAlgorithm::AesGcm128 => libcrux_aesgcm::AESGCM128_KEY_LEN,
+            AeadAlgorithm::AesGcm256 => libcrux_aesgcm::AESGCM256_KEY_LEN,
+        }
+    }
+
+    fn tag_length(&self) -> usize {
+        match self {
+            AeadAlgorithm::Direct(a) => a.tag_length(),
+            AeadAlgorithm::AesGcm128 => libcrux_aesgcm::AesGcm128::TAG_LEN,
+            AeadAlgorithm::AesGcm256 => libcrux_aesgcm::AesGcm256::TAG_LEN,
+        }
+    }
+
+    fn nonce_length(&self) -> usize {
+        match self {
+            AeadAlgorithm::Direct(a) => a.nonce_length(),
+            AeadAlgorithm::AesGcm128 => libcrux_aesgcm::AesGcm128::NONCE_LEN,
+            AeadAlgorithm::AesGcm256 => libcrux_aesgcm::AesGcm256::NONCE_LEN,
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> Clone for AeadAlgorithm<EC> {
+    // This is the default implemnentation, but we can't derive it because EC is not clone. (We
+    // don't expect it to, but we'd need "minimal derives" in Rust to make it derivable).
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct(arg0) => Self::Direct(arg0.clone()),
+            Self::AesGcm128 => Self::AesGcm128,
+            Self::AesGcm256 => Self::AesGcm256,
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> core::fmt::Debug for AeadAlgorithm<EC> {
+    // As for Clone
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Direct(arg0) => arg0.fmt(f),
+            Self::AesGcm128 => f.write_str("AesGcm128"),
+            Self::AesGcm256 => f.write_str("AesGcm256"),
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> PartialEq for AeadAlgorithm<EC> {
+    // As for Clone
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Direct(l0), Self::Direct(r0)) => l0 == r0,
+            (Self::AesGcm128, Self::AesGcm128) => true,
+            (Self::AesGcm256, Self::AesGcm256) => true,
+            _ => false,
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> Eq for AeadAlgorithm<EC> {}
+
+impl<EC: ExtenderConfig> AsRef<[u8]> for Tag<EC> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Tag::Direct(tag) => tag.as_ref(),
+            Tag::AesGcm128(tag) => tag.as_ref(),
+            Tag::AesGcm256(tag) => tag.as_ref(),
+        }
+    }
+}

--- a/embedded-cal-libcrux/src/empty_impls.rs
+++ b/embedded-cal-libcrux/src/empty_impls.rs
@@ -27,34 +27,3 @@ impl<EC: ExtenderConfig> embedded_cal::HmacProvider for Extender<EC> {
         match state {}
     }
 }
-
-impl<EC: ExtenderConfig> embedded_cal::AeadProvider for Extender<EC> {
-    type Algorithm = embedded_cal::empty::NoAlgorithms;
-    type Key = embedded_cal::empty::NoAlgorithms;
-    type Tag = embedded_cal::empty::NoAlgorithms;
-
-    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
-        match alg {}
-    }
-
-    fn encrypt_in_place(
-        &mut self,
-        key: &Self::Key,
-        _nonce: &[u8],
-        _message: &mut [u8],
-        _aad: impl embedded_cal::AadGenerator,
-    ) -> Self::Tag {
-        match *key {}
-    }
-
-    fn decrypt_in_place(
-        &mut self,
-        key: &Self::Key,
-        _nonce: &[u8],
-        _message: &mut [u8],
-        _tag: &[u8],
-        _aad: impl embedded_cal::AadGenerator,
-    ) -> Result<(), embedded_cal::DecryptionFailed> {
-        match *key {}
-    }
-}

--- a/embedded-cal-libcrux/src/lib.rs
+++ b/embedded-cal-libcrux/src/lib.rs
@@ -4,6 +4,7 @@
 use embedded_cal::{Cal, plumbing::Plumbing};
 use libcrux_sha2::Digest;
 
+mod aead;
 mod empty_impls;
 mod hash;
 


### PR DESCRIPTION
This does all the busy work without the really juicy bits; based on #50. (Ie. just look at the top-most commit).

Missing are:
- Actual encryption / decryption (because libcrux and embedded-cal disagree on whether in-place or copied is the way to go)
- Tests (boooring ;-) )
- Adding hardware acceleration (won't happen in this PR)

Before we start discussing who can adjust in terms of in-place decryption: Did I maybe just miss how to do it with libcrux? (→ @franziskuskiefer @jschneider-bensch)