### PR TITLE
aesccm16_64_256 for nrf54

### DIFF
--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -241,7 +241,12 @@ impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
                 tag.copy_from_slice(&output_buf[message.len()..message.len() + 8]);
                 AeadTag::AesCcm16_64_128(tag)
             }
-            AeadKey::AesCcm16_64_256(_) => todo!(),
+            AeadKey::AesCcm16_64_256(_) => {
+                // The CCM00 peripheral is 128-bit only
+                // https://docs.nordicsemi.com/r/bundle/ps_nrf54L15/page/ccm.html-unique_2145434636
+                // https://docs.nordicsemi.com/r/bundle/ps_nrf54L15/page/ccm.html-register.KEY.VALUE
+                todo!()
+            }
         }
     }
 

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -41,6 +41,53 @@ impl EcbJob {
     }
 }
 
+// ── BA411E AES engine — cryptomaster DMA tags and command words ──────────────────────────────────
+//
+// Sources: sdk-nrf subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/{cmdma.h,cmaes.h,aead.c}
+//
+// DMATAG layout (input descriptors only; the pusher ignores dmatag on output descriptors):
+//   bits [3:0]  — engine selector  (DMATAG_BA411 = 1)
+//   bit    [4]  — config-register write flag  (DMATAG_CONFIG sets this)
+//   bit    [6]  — header/AAD data type flag   (DMATAG_DATATYPE_HEADER)
+//   bits [12:8] — trailing padding bytes to ignore  (DMATAG_IGN, see descriptor::dmatag_ign)
+//   bits [15:8] — config register offset when bit 4 is set
+
+const DMATAG_BA411: u32 = 1;
+
+// Config-register descriptors (bit 4 set; register offset in bits [15:8]):
+const DMATAG_AES_CFG: u32 = DMATAG_BA411 | (1 << 4); // offset 0x00 → 0x0011
+const DMATAG_AES_KEY: u32 = DMATAG_BA411 | (1 << 4) | (0x08 << 8); // offset 0x08 → 0x0811
+
+// Data descriptors:
+const DMATAG_AES_AAD: u32 = DMATAG_BA411 | (1 << 6); // DATATYPE_HEADER → 0x0041
+const DMATAG_AES_DATA: u32 = DMATAG_BA411; // plaintext / ciphertext / tag → 0x0001
+
+// Command words written as the first input descriptor (dmatag = DMATAG_AES_CFG):
+//   bits [15:8] — mode: 1 << (8 + mode_id); CCM mode_id = 5 → bit 13 → 0x2000
+//   bit     [0] — direction: 0 = encrypt, 1 = decrypt
+// Key size is NOT encoded here — the BA411E infers it from the byte count of the
+// key descriptor (16 bytes → AES-128, 32 bytes → AES-256).
+const AES_CCM_MODE: u32 = 1 << 13; // CMDMA_AEAD_MODE_SET(5)
+const AES_CMD_CCM_256_ENCRYPT: u32 = AES_CCM_MODE; // 0x2000
+const AES_CMD_CCM_256_DECRYPT: u32 = AES_CCM_MODE | 1; // 0x2001
+
+use crate::descriptor::{DescriptorChain, Input, Output, dmatag_ign};
+
+/// FIXME: the same as stm32 build_b0. Deduplicate it
+/// Build the CCM B0 block.
+fn build_b0(nonce: &[u8], msg_len: usize, a_len: usize, tag_len: usize) -> [u8; 16] {
+    let mut b0 = [0u8; 16];
+    let l = 15 - nonce.len();
+    b0[0] = ((l - 1) as u8) | (((tag_len - 2) / 2) as u8) << 3;
+    if a_len > 0 {
+        b0[0] |= 0x40;
+    }
+    b0[1..1 + nonce.len()].copy_from_slice(nonce);
+    let msg_len_bytes = (msg_len as u64).to_be_bytes();
+    b0[16 - l..].copy_from_slice(&msg_len_bytes[8 - l..]);
+    b0
+}
+
 fn collect_aad(aad: impl embedded_cal::AadGenerator) -> ([u8; 255], usize) {
     let mut buf = [0u8; 255];
     let mut len: usize = 0;
@@ -161,6 +208,152 @@ impl super::Nrf54l15Cal {
             .value(3)
             .write_value(u32::from_be_bytes(key[0..4].try_into().unwrap()));
     }
+
+    fn ccm256_encrypt(
+        &mut self,
+        key: &[u8; 32],
+        nonce: &[u8],
+        message: &mut [u8],
+        aad: &[u8],
+    ) -> [u8; 8] {
+        const TAG_LEN: usize = 8;
+        let cmd = AES_CMD_CCM_256_ENCRYPT.to_le_bytes();
+
+        // Header = B0 (16 B) + [aad_len_be (2 B) + aad] when AAD present,
+        // zero-padded to the next 16-byte multiple.
+        // Max size: 16 + 2 + 255 = 273 → pads to 288.
+        let b0 = build_b0(nonce, message.len(), aad.len(), TAG_LEN);
+        let mut header_buf = [0u8; 288];
+        let header_data_len = if aad.is_empty() {
+            header_buf[..16].copy_from_slice(&b0);
+            16
+        } else {
+            header_buf[..16].copy_from_slice(&b0);
+            header_buf[16] = (aad.len() >> 8) as u8;
+            header_buf[17] = (aad.len() & 0xFF) as u8;
+            header_buf[18..18 + aad.len()].copy_from_slice(aad);
+            18 + aad.len()
+        };
+        let header_padded_len = (header_data_len + 15) & !15;
+        let header_ign = header_padded_len - header_data_len;
+
+        // Plaintext, zero-padded to 16-byte multiple; max 255 B → 256 B.
+        let msg_padded_len = (message.len() + 15) & !15;
+        let msg_ign = msg_padded_len - message.len();
+        let mut msg_in_buf = [0u8; 256];
+        msg_in_buf[..message.len()].copy_from_slice(message);
+
+        let mut ct_buf = [0u8; 256];
+        let mut tag_out_buf = [0u8; 16];
+        // The BA411E emits one output byte per header input byte (intermediate
+        // CBC-MAC state). Absorb those into a scratch buffer so that ct_buf and
+        // tag_out_buf receive the correct ciphertext and tag.
+        let mut header_out_buf = [0u8; 288];
+
+        let mut input_chain: DescriptorChain<Input, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        let mut output_chain: DescriptorChain<Output, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+
+        input_chain.push(&cmd, DMATAG_AES_CFG);
+        input_chain.push(key, DMATAG_AES_KEY);
+        input_chain.push(
+            &header_buf[..header_padded_len],
+            DMATAG_AES_AAD | dmatag_ign(header_ign),
+        );
+        if !message.is_empty() {
+            input_chain.push(
+                &msg_in_buf[..msg_padded_len],
+                DMATAG_AES_DATA | dmatag_ign(msg_ign),
+            );
+        }
+        output_chain.push(&mut header_out_buf[..header_padded_len], 0);
+        if !message.is_empty() {
+            output_chain.push(&mut ct_buf[..msg_padded_len], 0);
+        }
+        output_chain.push(&mut tag_out_buf, 0);
+
+        self.execute_cryptomaster_dma(&mut input_chain, &mut output_chain);
+
+        message.copy_from_slice(&ct_buf[..message.len()]);
+
+        let mut tag = [0u8; TAG_LEN];
+        tag.copy_from_slice(&tag_out_buf[..TAG_LEN]);
+        tag
+    }
+
+    fn ccm256_decrypt(
+        &mut self,
+        key: &[u8; 32],
+        nonce: &[u8],
+        ciphertext: &mut [u8],
+        tag_in: &[u8],
+        aad: &[u8],
+    ) -> bool {
+        const TAG_LEN: usize = 8;
+        let cmd = AES_CMD_CCM_256_DECRYPT.to_le_bytes();
+
+        let b0 = build_b0(nonce, ciphertext.len(), aad.len(), TAG_LEN);
+        let mut header_buf = [0u8; 288];
+        let header_data_len = if aad.is_empty() {
+            header_buf[..16].copy_from_slice(&b0);
+            16
+        } else {
+            header_buf[..16].copy_from_slice(&b0);
+            header_buf[16] = (aad.len() >> 8) as u8;
+            header_buf[17] = (aad.len() & 0xFF) as u8;
+            header_buf[18..18 + aad.len()].copy_from_slice(aad);
+            18 + aad.len()
+        };
+        let header_padded_len = (header_data_len + 15) & !15;
+        let header_ign = header_padded_len - header_data_len;
+
+        let ct_padded_len = (ciphertext.len() + 15) & !15;
+        let ct_ign = ct_padded_len - ciphertext.len();
+        let mut ct_in_buf = [0u8; 256];
+        ct_in_buf[..ciphertext.len()].copy_from_slice(ciphertext);
+
+        // Expected tag padded to 16 B; engine outputs XOR(computed_tag, expected_tag).
+        // All-zero output means the tags match.
+        let mut tag_in_buf = [0u8; 16];
+        tag_in_buf[..TAG_LEN].copy_from_slice(&tag_in[..TAG_LEN]);
+
+        let mut pt_buf = [0u8; 256];
+        let mut xor_tag_buf = [0u8; 16];
+        let mut header_out_buf = [0u8; 288];
+
+        let mut input_chain: DescriptorChain<Input, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        let mut output_chain: DescriptorChain<Output, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+
+        input_chain.push(&cmd, DMATAG_AES_CFG);
+        input_chain.push(key, DMATAG_AES_KEY);
+        input_chain.push(
+            &header_buf[..header_padded_len],
+            DMATAG_AES_AAD | dmatag_ign(header_ign),
+        );
+        if !ciphertext.is_empty() {
+            input_chain.push(
+                &ct_in_buf[..ct_padded_len],
+                DMATAG_AES_DATA | dmatag_ign(ct_ign),
+            );
+        }
+        input_chain.push(&tag_in_buf, DMATAG_AES_DATA | dmatag_ign(16 - TAG_LEN));
+        output_chain.push(&mut header_out_buf[..header_padded_len], 0);
+        if !ciphertext.is_empty() {
+            output_chain.push(&mut pt_buf[..ct_padded_len], 0);
+        }
+        output_chain.push(&mut xor_tag_buf, 0);
+
+        self.execute_cryptomaster_dma(&mut input_chain, &mut output_chain);
+
+        let mac_ok = xor_tag_buf[..TAG_LEN].iter().all(|&b| b == 0);
+        if mac_ok {
+            ciphertext.copy_from_slice(&pt_buf[..ciphertext.len()]);
+        }
+        mac_ok
+    }
 }
 
 impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
@@ -241,11 +434,10 @@ impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
                 tag.copy_from_slice(&output_buf[message.len()..message.len() + 8]);
                 AeadTag::AesCcm16_64_128(tag)
             }
-            AeadKey::AesCcm16_64_256(_) => {
-                // The CCM00 peripheral is 128-bit only
-                // https://docs.nordicsemi.com/r/bundle/ps_nrf54L15/page/ccm.html-unique_2145434636
-                // https://docs.nordicsemi.com/r/bundle/ps_nrf54L15/page/ccm.html-register.KEY.VALUE
-                todo!()
+            AeadKey::AesCcm16_64_256(key_bytes) => {
+                let (aad_buf, aad_len) = collect_aad(aad);
+                let tag = self.ccm256_encrypt(&key_bytes, nonce, message, &aad_buf[..aad_len]);
+                AeadTag::AesCcm16_64_256(tag)
             }
         }
     }
@@ -326,7 +518,14 @@ impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
                 cyphertext.copy_from_slice(&plaintext_buf[..cyphertext.len()]);
                 Ok(())
             }
-            AeadKey::AesCcm16_64_256(_) => todo!(),
+            AeadKey::AesCcm16_64_256(key_bytes) => {
+                let (aad_buf, aad_len) = collect_aad(aad);
+                if self.ccm256_decrypt(&key_bytes, nonce, cyphertext, tag, &aad_buf[..aad_len]) {
+                    Ok(())
+                } else {
+                    Err(embedded_cal::DecryptionFailed)
+                }
+            }
         }
     }
 }

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -73,21 +73,6 @@ const AES_CMD_CCM_256_DECRYPT: u32 = AES_CCM_MODE | 1; // 0x2001
 
 use crate::descriptor::{DescriptorChain, Input, Output, dmatag_ign};
 
-/// FIXME: the same as stm32 build_b0. Deduplicate it
-/// Build the CCM B0 block.
-fn build_b0(nonce: &[u8], msg_len: usize, a_len: usize, tag_len: usize) -> [u8; 16] {
-    let mut b0 = [0u8; 16];
-    let l = 15 - nonce.len();
-    b0[0] = ((l - 1) as u8) | (((tag_len - 2) / 2) as u8) << 3;
-    if a_len > 0 {
-        b0[0] |= 0x40;
-    }
-    b0[1..1 + nonce.len()].copy_from_slice(nonce);
-    let msg_len_bytes = (msg_len as u64).to_be_bytes();
-    b0[16 - l..].copy_from_slice(&msg_len_bytes[8 - l..]);
-    b0
-}
-
 fn collect_aad(aad: impl embedded_cal::AadGenerator) -> ([u8; 255], usize) {
     let mut buf = [0u8; 255];
     let mut len: usize = 0;
@@ -222,7 +207,7 @@ impl super::Nrf54l15Cal {
         // Header = B0 (16 B) + [aad_len_be (2 B) + aad] when AAD present,
         // zero-padded to the next 16-byte multiple.
         // Max size: 16 + 2 + 255 = 273 → pads to 288.
-        let b0 = build_b0(nonce, message.len(), aad.len(), TAG_LEN);
+        let b0 = embedded_cal::build_b0(nonce, message.len(), aad.len(), TAG_LEN);
         let mut header_buf = [0u8; 288];
         let header_data_len = if aad.is_empty() {
             header_buf[..16].copy_from_slice(&b0);
@@ -293,7 +278,7 @@ impl super::Nrf54l15Cal {
         const TAG_LEN: usize = 8;
         let cmd = AES_CMD_CCM_256_DECRYPT.to_le_bytes();
 
-        let b0 = build_b0(nonce, ciphertext.len(), aad.len(), TAG_LEN);
+        let b0 = embedded_cal::build_b0(nonce, ciphertext.len(), aad.len(), TAG_LEN);
         let mut header_buf = [0u8; 288];
         let header_data_len = if aad.is_empty() {
             header_buf[..16].copy_from_slice(&b0);

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -1,35 +1,327 @@
-// FIXME: Something is probably there, just not implemented yet.
-//
-// (This would be more concise
-// <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
+/// A single entry in the CCM DMA job list.
+///
+/// The hardware walks a null-terminated array of these to locate each logical
+/// piece of the CCM input or output (lengths, AAD, message data). The layout
+/// is dictated by the CRACEN hardware ABI and must remain `#[repr(C, packed)]`.
+/// `ptr` is stored as `u32` because the hardware register holds a 32-bit address.
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+struct EcbJob {
+    ptr: u32,
+    attr_and_len: [u8; 4], // [len_lo, len_mid, len_hi, attr]
+}
+
+/// Attribute tags that identify the role of each [`EcbJob`] to the hardware.
+///
+/// The discriminant values are fixed by the CRACEN CCM peripheral specification.
+#[repr(u8)]
+enum EcbJobAttr {
+    /// Length of the AAD in bytes.
+    Alen = 11,
+    /// Length of the message (plaintext or ciphertext, excluding tag) in bytes.
+    Mlen = 12,
+    /// AAD payload bytes.
+    Adata = 13,
+    /// Message payload bytes (plaintext for encrypt; ciphertext+tag for decrypt).
+    Mdata = 14,
+}
+
+impl EcbJob {
+    fn new(ptr: *const u8, length: u8, tag: EcbJobAttr) -> Self {
+        EcbJob {
+            ptr: ptr as u32,
+            attr_and_len: [length, 0, 0, tag as u8],
+        }
+    }
+    const fn zero() -> Self {
+        EcbJob {
+            ptr: 0,
+            attr_and_len: [0; 4],
+        }
+    }
+}
+
+fn collect_aad(aad: impl embedded_cal::AadGenerator) -> ([u8; 255], usize) {
+    let mut buf = [0u8; 255];
+    let mut len: usize = 0;
+    for chunk in aad.items() {
+        buf[len..len + chunk.len()].copy_from_slice(chunk);
+        len += chunk.len();
+    }
+    (buf, len)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AeadAlgorithm {
+    AesCcm16_64_128,
+    AesCcm16_64_256,
+}
+
+impl embedded_cal::AeadAlgorithm for AeadAlgorithm {
+    fn key_length(&self) -> usize {
+        match self {
+            AeadAlgorithm::AesCcm16_64_128 => 16,
+            AeadAlgorithm::AesCcm16_64_256 => 32,
+        }
+    }
+
+    fn tag_length(&self) -> usize {
+        8
+    }
+
+    fn nonce_length(&self) -> usize {
+        13
+    }
+
+    fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
+        match number.into() {
+            10 => Some(AeadAlgorithm::AesCcm16_64_128),
+            11 => Some(AeadAlgorithm::AesCcm16_64_256),
+            _ => None,
+        }
+    }
+}
+
+pub enum AeadKey {
+    AesCcm16_64_128([u8; 16]),
+    AesCcm16_64_256([u8; 32]),
+}
+
+pub enum AeadTag {
+    AesCcm16_64_128([u8; 8]),
+    AesCcm16_64_256([u8; 8]),
+}
+
+impl AsRef<[u8]> for AeadTag {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            AeadTag::AesCcm16_64_128(r) => &r[..],
+            AeadTag::AesCcm16_64_256(r) => &r[..],
+        }
+    }
+}
+
+impl super::Nrf54l15Cal {
+    fn ccm_run(&mut self) -> bool {
+        use nrf_pac::ccm::vals;
+        self.ccm.tasks_start().write_value(1);
+        while self.ccm.events_end().read() == 0 {}
+        self.ccm.events_end().write_value(0);
+        self.ccm.macstatus().read().macstatus() == vals::Macstatus::CHECK_PASSED
+    }
+
+    fn ccm_setup(&mut self, mode: nrf_pac::ccm::vals::Mode) {
+        use nrf_pac::ccm::vals;
+        self.ccm
+            .enable()
+            .write(|w| w.set_enable(vals::Enable::ENABLED));
+        // For non-BT protocols, adatamask must be 0xFF
+        self.ccm.adatamask().write(|w| w.set_adatamask(0xFF));
+        self.ccm.mode().write(|w| {
+            w.set_mode(mode);
+            w.set_maclen(vals::Maclen::M8);
+            w.set_protocol(vals::Protocol::IEEE802154);
+        });
+    }
+
+    fn ccm_write_nonce(&mut self, nonce: &[u8]) {
+        self.ccm
+            .nonce()
+            .value(0)
+            .write_value(u32::from_be_bytes(nonce[9..].try_into().unwrap()));
+        self.ccm
+            .nonce()
+            .value(1)
+            .write_value(u32::from_be_bytes(nonce[5..9].try_into().unwrap()));
+        self.ccm
+            .nonce()
+            .value(2)
+            .write_value(u32::from_be_bytes(nonce[1..5].try_into().unwrap()));
+        self.ccm
+            .nonce()
+            .value(3)
+            .write_value(u32::from_be_bytes([0, 0, 0, nonce[0]]));
+    }
+
+    fn ccm_write_key(&mut self, key: &[u8; 16]) {
+        self.ccm
+            .key()
+            .value(0)
+            .write_value(u32::from_be_bytes(key[12..16].try_into().unwrap()));
+        self.ccm
+            .key()
+            .value(1)
+            .write_value(u32::from_be_bytes(key[8..12].try_into().unwrap()));
+        self.ccm
+            .key()
+            .value(2)
+            .write_value(u32::from_be_bytes(key[4..8].try_into().unwrap()));
+        self.ccm
+            .key()
+            .value(3)
+            .write_value(u32::from_be_bytes(key[0..4].try_into().unwrap()));
+    }
+}
 
 impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
-    type Algorithm = embedded_cal::empty::NoAlgorithms;
-    type Key = embedded_cal::empty::NoAlgorithms;
-    type Tag = embedded_cal::empty::NoAlgorithms;
+    type Algorithm = AeadAlgorithm;
+    type Key = AeadKey;
+    type Tag = AeadTag;
 
-    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
-        match alg {}
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, key: &[u8]) -> Self::Key {
+        match alg {
+            AeadAlgorithm::AesCcm16_64_128 => {
+                AeadKey::AesCcm16_64_128(key.try_into().expect("key length mismatch"))
+            }
+            AeadAlgorithm::AesCcm16_64_256 => {
+                AeadKey::AesCcm16_64_256(key.try_into().expect("key length mismatch"))
+            }
+        }
     }
 
     fn encrypt_in_place(
         &mut self,
         key: &Self::Key,
-        _nonce: &[u8],
-        _message: &mut [u8],
-        _aad: impl embedded_cal::AadGenerator,
+        nonce: &[u8],
+        message: &mut [u8],
+        aad: impl embedded_cal::AadGenerator,
     ) -> Self::Tag {
-        match *key {}
+        use nrf_pac::ccm::vals;
+
+        match *key {
+            AeadKey::AesCcm16_64_128(key) => {
+                self.ccm_setup(vals::Mode::ENCRYPTION);
+
+                let (aad_input_buf, aad_len) = collect_aad(aad);
+
+                let alen_input_buf = (aad_len as u32).to_le_bytes();
+                let mlen_input_buf = (message.len() as u32).to_le_bytes();
+
+                let mut input_jobs = [
+                    EcbJob::new(alen_input_buf.as_ptr(), 2, EcbJobAttr::Alen),
+                    EcbJob::new(mlen_input_buf.as_ptr(), 2, EcbJobAttr::Mlen),
+                    EcbJob::new(aad_input_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
+                    EcbJob::new(message.as_ptr(), message.len() as u8, EcbJobAttr::Mdata),
+                    EcbJob::zero(),
+                ];
+
+                let alen_output_buf = (aad_len as u32).to_le_bytes();
+                let mlen_output_buf = (message.len() as u32).to_le_bytes();
+                let aad_output_buf = [0x00; 256];
+                let mut output_buf = [0x00; 256];
+
+                let mut output_jobs = [
+                    EcbJob::new(alen_output_buf.as_ptr(), 2, EcbJobAttr::Alen),
+                    EcbJob::new(mlen_output_buf.as_ptr(), 2, EcbJobAttr::Mlen),
+                    EcbJob::new(aad_output_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
+                    EcbJob::new(
+                        output_buf.as_mut_ptr(),
+                        (message.len() + 8) as u8,
+                        EcbJobAttr::Mdata,
+                    ),
+                    EcbJob::zero(),
+                ];
+
+                let input_jobs_ptr = core::ptr::addr_of_mut!(input_jobs) as u32;
+                let output_jobs_ptr = core::ptr::addr_of_mut!(output_jobs) as u32;
+
+                self.ccm_write_key(&key);
+                self.ccm_write_nonce(nonce);
+
+                self.ccm.in_().ptr().write_value(input_jobs_ptr);
+                self.ccm.out().ptr().write_value(output_jobs_ptr);
+
+                self.ccm_run();
+                self.ccm
+                    .enable()
+                    .write(|w| w.set_enable(vals::Enable::DISABLED));
+
+                let mut tag = [0u8; 8];
+                message.copy_from_slice(&output_buf[..message.len()]);
+                tag.copy_from_slice(&output_buf[message.len()..message.len() + 8]);
+                AeadTag::AesCcm16_64_128(tag)
+            }
+            AeadKey::AesCcm16_64_256(_) => todo!(),
+        }
     }
 
     fn decrypt_in_place(
         &mut self,
         key: &Self::Key,
-        _nonce: &[u8],
-        _message: &mut [u8],
-        _tag: &[u8],
-        _aad: impl embedded_cal::AadGenerator,
+        nonce: &[u8],
+        cyphertext: &mut [u8],
+        tag: &[u8],
+        aad: impl embedded_cal::AadGenerator,
     ) -> Result<(), embedded_cal::DecryptionFailed> {
-        match *key {}
+        use nrf_pac::ccm::vals;
+
+        match *key {
+            AeadKey::AesCcm16_64_128(key) => {
+                self.ccm_setup(vals::Mode::FAST_DECRYPTION);
+
+                let (aad_buf, aad_len) = collect_aad(aad);
+
+                let alen_input_buf = (aad_len as u32).to_le_bytes();
+                let ciphertext_tag_len = cyphertext.len() + 8;
+                let mlen_input_buf = (ciphertext_tag_len as u32).to_le_bytes();
+
+                let mut ciphertext_tag_buf = [0u8; 256];
+                ciphertext_tag_buf[..cyphertext.len()].copy_from_slice(cyphertext);
+                ciphertext_tag_buf[cyphertext.len()..ciphertext_tag_len].copy_from_slice(tag);
+
+                let mut input_jobs: [EcbJob; 5] = [
+                    EcbJob::new(alen_input_buf.as_ptr(), 2, EcbJobAttr::Alen),
+                    EcbJob::new(mlen_input_buf.as_ptr(), 2, EcbJobAttr::Mlen),
+                    EcbJob::new(aad_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
+                    EcbJob::new(
+                        ciphertext_tag_buf.as_ptr(),
+                        ciphertext_tag_len as u8,
+                        EcbJobAttr::Mdata,
+                    ),
+                    EcbJob::zero(),
+                ];
+
+                let alen_output_buf = (aad_len as u32).to_le_bytes();
+                let mlen_output_buf = (cyphertext.len() as u32).to_le_bytes();
+                let aad_out_buf = [0u8; 255];
+                let mut plaintext_buf = [0u8; 263];
+
+                // Decrypt output mirrors encrypt INPUT order: Adata=AAD, Mdata=plaintext.
+                let mut output_jobs: [EcbJob; 5] = [
+                    EcbJob::new(alen_output_buf.as_ptr(), 2, EcbJobAttr::Alen),
+                    EcbJob::new(mlen_output_buf.as_ptr(), 2, EcbJobAttr::Mlen),
+                    EcbJob::new(aad_out_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
+                    EcbJob::new(
+                        plaintext_buf.as_mut_ptr(),
+                        cyphertext.len() as u8,
+                        EcbJobAttr::Mdata,
+                    ),
+                    EcbJob::zero(),
+                ];
+
+                let input_jobs_ptr = core::ptr::addr_of_mut!(input_jobs) as u32;
+                let output_jobs_ptr = core::ptr::addr_of_mut!(output_jobs) as u32;
+
+                self.ccm_write_key(&key);
+                self.ccm_write_nonce(nonce);
+
+                self.ccm.in_().ptr().write_value(input_jobs_ptr);
+                self.ccm.out().ptr().write_value(output_jobs_ptr);
+
+                let mac_ok = self.ccm_run();
+                self.ccm
+                    .enable()
+                    .write(|w| w.set_enable(vals::Enable::DISABLED));
+
+                if !mac_ok {
+                    return Err(embedded_cal::DecryptionFailed);
+                }
+
+                // Message should only be copied after the verification
+                cyphertext.copy_from_slice(&plaintext_buf[..cyphertext.len()]);
+                Ok(())
+            }
+            AeadKey::AesCcm16_64_256(_) => todo!(),
+        }
     }
 }

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -1,46 +1,3 @@
-/// A single entry in the CCM DMA job list.
-///
-/// The hardware walks a null-terminated array of these to locate each logical
-/// piece of the CCM input or output (lengths, AAD, message data). The layout
-/// is dictated by the CRACEN hardware ABI and must remain `#[repr(C, packed)]`.
-/// `ptr` is stored as `u32` because the hardware register holds a 32-bit address.
-#[repr(C, packed)]
-#[derive(Copy, Clone)]
-struct EcbJob {
-    ptr: u32,
-    attr_and_len: [u8; 4], // [len_lo, len_mid, len_hi, attr]
-}
-
-/// Attribute tags that identify the role of each [`EcbJob`] to the hardware.
-///
-/// The discriminant values are fixed by the CRACEN CCM peripheral specification.
-#[repr(u8)]
-enum EcbJobAttr {
-    /// Length of the AAD in bytes.
-    Alen = 11,
-    /// Length of the message (plaintext or ciphertext, excluding tag) in bytes.
-    Mlen = 12,
-    /// AAD payload bytes.
-    Adata = 13,
-    /// Message payload bytes (plaintext for encrypt; ciphertext+tag for decrypt).
-    Mdata = 14,
-}
-
-impl EcbJob {
-    fn new(ptr: *const u8, length: u8, tag: EcbJobAttr) -> Self {
-        EcbJob {
-            ptr: ptr as u32,
-            attr_and_len: [length, 0, 0, tag as u8],
-        }
-    }
-    const fn zero() -> Self {
-        EcbJob {
-            ptr: 0,
-            attr_and_len: [0; 4],
-        }
-    }
-}
-
 // ── BA411E AES engine — cryptomaster DMA tags and command words ──────────────────────────────────
 //
 // Sources: sdk-nrf subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/{cmdma.h,cmaes.h,aead.c}
@@ -68,8 +25,8 @@ const DMATAG_AES_DATA: u32 = DMATAG_BA411; // plaintext / ciphertext / tag → 0
 // Key size is NOT encoded here — the BA411E infers it from the byte count of the
 // key descriptor (16 bytes → AES-128, 32 bytes → AES-256).
 const AES_CCM_MODE: u32 = 1 << 13; // CMDMA_AEAD_MODE_SET(5)
-const AES_CMD_CCM_256_ENCRYPT: u32 = AES_CCM_MODE; // 0x2000
-const AES_CMD_CCM_256_DECRYPT: u32 = AES_CCM_MODE | 1; // 0x2001
+const AES_CMD_CCM_ENCRYPT: u32 = AES_CCM_MODE; // 0x2000
+const AES_CMD_CCM_DECRYPT: u32 = AES_CCM_MODE | 1; // 0x2001
 
 use crate::descriptor::{DescriptorChain, Input, Output, dmatag_ign};
 
@@ -134,75 +91,21 @@ impl AsRef<[u8]> for AeadTag {
 }
 
 impl super::Nrf54l15Cal {
-    fn ccm_run(&mut self) -> bool {
-        use nrf_pac::ccm::vals;
-        self.ccm.tasks_start().write_value(1);
-        while self.ccm.events_end().read() == 0 {}
-        self.ccm.events_end().write_value(0);
-        self.ccm.macstatus().read().macstatus() == vals::Macstatus::CHECK_PASSED
-    }
-
-    fn ccm_setup(&mut self, mode: nrf_pac::ccm::vals::Mode) {
-        use nrf_pac::ccm::vals;
-        self.ccm
-            .enable()
-            .write(|w| w.set_enable(vals::Enable::ENABLED));
-        // For non-BT protocols, adatamask must be 0xFF
-        self.ccm.adatamask().write(|w| w.set_adatamask(0xFF));
-        self.ccm.mode().write(|w| {
-            w.set_mode(mode);
-            w.set_maclen(vals::Maclen::M8);
-            w.set_protocol(vals::Protocol::IEEE802154);
-        });
-    }
-
-    fn ccm_write_nonce(&mut self, nonce: &[u8]) {
-        self.ccm
-            .nonce()
-            .value(0)
-            .write_value(u32::from_be_bytes(nonce[9..].try_into().unwrap()));
-        self.ccm
-            .nonce()
-            .value(1)
-            .write_value(u32::from_be_bytes(nonce[5..9].try_into().unwrap()));
-        self.ccm
-            .nonce()
-            .value(2)
-            .write_value(u32::from_be_bytes(nonce[1..5].try_into().unwrap()));
-        self.ccm
-            .nonce()
-            .value(3)
-            .write_value(u32::from_be_bytes([0, 0, 0, nonce[0]]));
-    }
-
-    fn ccm_write_key(&mut self, key: &[u8; 16]) {
-        self.ccm
-            .key()
-            .value(0)
-            .write_value(u32::from_be_bytes(key[12..16].try_into().unwrap()));
-        self.ccm
-            .key()
-            .value(1)
-            .write_value(u32::from_be_bytes(key[8..12].try_into().unwrap()));
-        self.ccm
-            .key()
-            .value(2)
-            .write_value(u32::from_be_bytes(key[4..8].try_into().unwrap()));
-        self.ccm
-            .key()
-            .value(3)
-            .write_value(u32::from_be_bytes(key[0..4].try_into().unwrap()));
-    }
-
-    fn ccm256_encrypt(
+    fn ccm_encrypt<const KEY_LEN: usize>(
         &mut self,
-        key: &[u8; 32],
+        key: &[u8; KEY_LEN],
         nonce: &[u8],
         message: &mut [u8],
         aad: &[u8],
     ) -> [u8; 8] {
+        const {
+            assert!(
+                KEY_LEN == 16 || KEY_LEN == 32,
+                "AES-CCM key must be 16 (AES-128) or 32 (AES-256) bytes"
+            )
+        };
         const TAG_LEN: usize = 8;
-        let cmd = AES_CMD_CCM_256_ENCRYPT.to_le_bytes();
+        let cmd = AES_CMD_CCM_ENCRYPT.to_le_bytes();
 
         // Header = B0 (16 B) + [aad_len_be (2 B) + aad] when AAD present,
         // zero-padded to the next 16-byte multiple.
@@ -267,16 +170,22 @@ impl super::Nrf54l15Cal {
         tag
     }
 
-    fn ccm256_decrypt(
+    fn ccm_decrypt<const KEY_LEN: usize>(
         &mut self,
-        key: &[u8; 32],
+        key: &[u8; KEY_LEN],
         nonce: &[u8],
         ciphertext: &mut [u8],
         tag_in: &[u8],
         aad: &[u8],
     ) -> bool {
+        const {
+            assert!(
+                KEY_LEN == 16 || KEY_LEN == 32,
+                "AES-CCM key must be 16 (AES-128) or 32 (AES-256) bytes"
+            )
+        };
         const TAG_LEN: usize = 8;
-        let cmd = AES_CMD_CCM_256_DECRYPT.to_le_bytes();
+        let cmd = AES_CMD_CCM_DECRYPT.to_le_bytes();
 
         let b0 = embedded_cal::build_b0(nonce, ciphertext.len(), aad.len(), TAG_LEN);
         let mut header_buf = [0u8; 288];
@@ -364,64 +273,14 @@ impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
         message: &mut [u8],
         aad: impl embedded_cal::AadGenerator,
     ) -> Self::Tag {
-        use nrf_pac::ccm::vals;
-
-        match *key {
-            AeadKey::AesCcm16_64_128(key) => {
-                self.ccm_setup(vals::Mode::ENCRYPTION);
-
-                let (aad_input_buf, aad_len) = collect_aad(aad);
-
-                let alen_input_buf = (aad_len as u32).to_le_bytes();
-                let mlen_input_buf = (message.len() as u32).to_le_bytes();
-
-                let mut input_jobs = [
-                    EcbJob::new(alen_input_buf.as_ptr(), 2, EcbJobAttr::Alen),
-                    EcbJob::new(mlen_input_buf.as_ptr(), 2, EcbJobAttr::Mlen),
-                    EcbJob::new(aad_input_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
-                    EcbJob::new(message.as_ptr(), message.len() as u8, EcbJobAttr::Mdata),
-                    EcbJob::zero(),
-                ];
-
-                let alen_output_buf = (aad_len as u32).to_le_bytes();
-                let mlen_output_buf = (message.len() as u32).to_le_bytes();
-                let aad_output_buf = [0x00; 256];
-                let mut output_buf = [0x00; 256];
-
-                let mut output_jobs = [
-                    EcbJob::new(alen_output_buf.as_ptr(), 2, EcbJobAttr::Alen),
-                    EcbJob::new(mlen_output_buf.as_ptr(), 2, EcbJobAttr::Mlen),
-                    EcbJob::new(aad_output_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
-                    EcbJob::new(
-                        output_buf.as_mut_ptr(),
-                        (message.len() + 8) as u8,
-                        EcbJobAttr::Mdata,
-                    ),
-                    EcbJob::zero(),
-                ];
-
-                let input_jobs_ptr = core::ptr::addr_of_mut!(input_jobs) as u32;
-                let output_jobs_ptr = core::ptr::addr_of_mut!(output_jobs) as u32;
-
-                self.ccm_write_key(&key);
-                self.ccm_write_nonce(nonce);
-
-                self.ccm.in_().ptr().write_value(input_jobs_ptr);
-                self.ccm.out().ptr().write_value(output_jobs_ptr);
-
-                self.ccm_run();
-                self.ccm
-                    .enable()
-                    .write(|w| w.set_enable(vals::Enable::DISABLED));
-
-                let mut tag = [0u8; 8];
-                message.copy_from_slice(&output_buf[..message.len()]);
-                tag.copy_from_slice(&output_buf[message.len()..message.len() + 8]);
+        let (aad_buf, aad_len) = collect_aad(aad);
+        match key {
+            AeadKey::AesCcm16_64_128(key_bytes) => {
+                let tag = self.ccm_encrypt(key_bytes, nonce, message, &aad_buf[..aad_len]);
                 AeadTag::AesCcm16_64_128(tag)
             }
             AeadKey::AesCcm16_64_256(key_bytes) => {
-                let (aad_buf, aad_len) = collect_aad(aad);
-                let tag = self.ccm256_encrypt(&key_bytes, nonce, message, &aad_buf[..aad_len]);
+                let tag = self.ccm_encrypt(key_bytes, nonce, message, &aad_buf[..aad_len]);
                 AeadTag::AesCcm16_64_256(tag)
             }
         }
@@ -435,82 +294,19 @@ impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
         tag: &[u8],
         aad: impl embedded_cal::AadGenerator,
     ) -> Result<(), embedded_cal::DecryptionFailed> {
-        use nrf_pac::ccm::vals;
-
-        match *key {
-            AeadKey::AesCcm16_64_128(key) => {
-                self.ccm_setup(vals::Mode::FAST_DECRYPTION);
-
-                let (aad_buf, aad_len) = collect_aad(aad);
-
-                let alen_input_buf = (aad_len as u32).to_le_bytes();
-                let ciphertext_tag_len = cyphertext.len() + 8;
-                let mlen_input_buf = (ciphertext_tag_len as u32).to_le_bytes();
-
-                let mut ciphertext_tag_buf = [0u8; 256];
-                ciphertext_tag_buf[..cyphertext.len()].copy_from_slice(cyphertext);
-                ciphertext_tag_buf[cyphertext.len()..ciphertext_tag_len].copy_from_slice(tag);
-
-                let mut input_jobs: [EcbJob; 5] = [
-                    EcbJob::new(alen_input_buf.as_ptr(), 2, EcbJobAttr::Alen),
-                    EcbJob::new(mlen_input_buf.as_ptr(), 2, EcbJobAttr::Mlen),
-                    EcbJob::new(aad_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
-                    EcbJob::new(
-                        ciphertext_tag_buf.as_ptr(),
-                        ciphertext_tag_len as u8,
-                        EcbJobAttr::Mdata,
-                    ),
-                    EcbJob::zero(),
-                ];
-
-                let alen_output_buf = (aad_len as u32).to_le_bytes();
-                let mlen_output_buf = (cyphertext.len() as u32).to_le_bytes();
-                let aad_out_buf = [0u8; 255];
-                let mut plaintext_buf = [0u8; 263];
-
-                // Decrypt output mirrors encrypt INPUT order: Adata=AAD, Mdata=plaintext.
-                let mut output_jobs: [EcbJob; 5] = [
-                    EcbJob::new(alen_output_buf.as_ptr(), 2, EcbJobAttr::Alen),
-                    EcbJob::new(mlen_output_buf.as_ptr(), 2, EcbJobAttr::Mlen),
-                    EcbJob::new(aad_out_buf.as_ptr(), aad_len as u8, EcbJobAttr::Adata),
-                    EcbJob::new(
-                        plaintext_buf.as_mut_ptr(),
-                        cyphertext.len() as u8,
-                        EcbJobAttr::Mdata,
-                    ),
-                    EcbJob::zero(),
-                ];
-
-                let input_jobs_ptr = core::ptr::addr_of_mut!(input_jobs) as u32;
-                let output_jobs_ptr = core::ptr::addr_of_mut!(output_jobs) as u32;
-
-                self.ccm_write_key(&key);
-                self.ccm_write_nonce(nonce);
-
-                self.ccm.in_().ptr().write_value(input_jobs_ptr);
-                self.ccm.out().ptr().write_value(output_jobs_ptr);
-
-                let mac_ok = self.ccm_run();
-                self.ccm
-                    .enable()
-                    .write(|w| w.set_enable(vals::Enable::DISABLED));
-
-                if !mac_ok {
-                    return Err(embedded_cal::DecryptionFailed);
-                }
-
-                // Message should only be copied after the verification
-                cyphertext.copy_from_slice(&plaintext_buf[..cyphertext.len()]);
-                Ok(())
+        let (aad_buf, aad_len) = collect_aad(aad);
+        let ok = match key {
+            AeadKey::AesCcm16_64_128(key_bytes) => {
+                self.ccm_decrypt(key_bytes, nonce, cyphertext, tag, &aad_buf[..aad_len])
             }
             AeadKey::AesCcm16_64_256(key_bytes) => {
-                let (aad_buf, aad_len) = collect_aad(aad);
-                if self.ccm256_decrypt(&key_bytes, nonce, cyphertext, tag, &aad_buf[..aad_len]) {
-                    Ok(())
-                } else {
-                    Err(embedded_cal::DecryptionFailed)
-                }
+                self.ccm_decrypt(key_bytes, nonce, cyphertext, tag, &aad_buf[..aad_len])
             }
+        };
+        if ok {
+            Ok(())
+        } else {
+            Err(embedded_cal::DecryptionFailed)
         }
     }
 }

--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -1,4 +1,4 @@
-// ── BA411E AES engine — cryptomaster DMA tags and command words ──────────────────────────────────
+// # BA411E AES engine — cryptomaster DMA tags and command words
 //
 // Sources: sdk-nrf subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/{cmdma.h,cmaes.h,aead.c}
 //

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -22,11 +22,14 @@ struct Descriptor {
     ///
     /// Should be LAST_DESC_PTR in case of the last descriptor of the chain.
     next: *mut Descriptor,
-    // FIXME: Improve documentation, explain the magic number 0x2000_0000
-    /// Length, in bytes, of the memory region described by `addr`.
+    /// Length of the memory region in bytes, with `DMA_REALIGN` (bit 29) set.
+    /// `DMA_REALIGN` tells the DMA engine to re-align its internal state at the end of this
+    /// descriptor before starting the next one.
     sz: u32,
-    // FIXME: Improve documentation, enum all possible tags.
-    /// DMA attribute / tag field.
+    /// Routes this descriptor to a hardware engine and describes the data role.
+    /// Lower bits select the engine (e.g. `DMATAG_BA411 = 1` for AES). Bit 4 marks a
+    /// configuration register write; bits [6:5] encode the data type; bits [12:8] encode the
+    /// number of trailing padding bytes the engine should ignore (`DMATAG_IGN`).
     dmatag: u32,
 }
 
@@ -108,7 +111,13 @@ impl<'mem, Direction, const N: usize> DescriptorChain<'mem, Direction, N> {
             self.descs[i - 1].next = &mut self.descs[i];
         }
         if self.count > 0 {
-            self.descs[self.count - 1].next = LAST_DESC_PTR;
+            let last = &mut self.descs[self.count - 1];
+            last.next = LAST_DESC_PTR;
+            // DMATAG_LAST (bit 5) on the final descriptor signals the engine to
+            // finalize the operation (produce output / authentication tag).
+            // sx_cmdma_finalize_descs() in the Nordic SDK applies this to both
+            // the last input and last output descriptor of every DMA operation.
+            last.dmatag |= 1 << 5;
         }
     }
 
@@ -150,6 +159,7 @@ impl<'mem, const N: usize> DescriptorChain<'mem, Input, N> {
     /// # Safety / Correctness requirements
     ///
     /// - `data` must be DMA-accessible memory.
+    /// - `data.len()` must be a multiple of 4.
     pub(crate) fn push(&mut self, data: &'mem [u8], dmatag: u32) {
         self.push_descriptor(Descriptor::new(
             data.as_ptr() as *mut u8,
@@ -170,6 +180,12 @@ impl<'mem, const N: usize> DescriptorChain<'mem, Output, N> {
     pub(crate) fn push(&mut self, data: &'mem mut [u8], dmatag: u32) {
         self.push_descriptor(Descriptor::new(data.as_mut_ptr(), sz(data.len()), dmatag));
     }
+}
+
+/// Encodes `n` ignored trailing bytes into a dmatag (bits [12:8]).
+/// The engine will process the full buffer but treat the last `n` bytes as zero-padding.
+pub(crate) const fn dmatag_ign(n: usize) -> u32 {
+    (n as u32) << 8
 }
 
 /// Asserts that size is a multiple of 4, and ORs in the DMA_REALIGN constant.

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -14,12 +14,17 @@ pub struct Nrf54l15Cal {
     // it's possible to have a more granular ownership
     cracen: cracen::Cracen,
     cracen_core: cracencore::Cracencore,
+    ccm: nrf_pac::ccm::Ccm,
 }
 
 impl embedded_cal::Cal for Nrf54l15Cal {}
 
 impl Nrf54l15Cal {
-    pub fn new(cracen: cracen::Cracen, cracen_core: cracencore::Cracencore) -> Self {
+    pub fn new(
+        cracen: cracen::Cracen,
+        cracen_core: cracencore::Cracencore,
+        ccm: nrf_pac::ccm::Ccm,
+    ) -> Self {
         // Enable cryptomaster
         cracen.enable().write(|w| {
             w.set_cryptomaster(true);
@@ -40,6 +45,7 @@ impl Nrf54l15Cal {
         Self {
             cracen,
             cracen_core,
+            ccm,
         }
     }
 }

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -7,7 +7,9 @@ mod try_rng;
 use descriptor::{DescriptorChain, Input, Output};
 use nrf_pac::{cracen, cracencore};
 
-const MAX_DESCRIPTOR_CHAIN_LEN: usize = 4;
+// CCM-256 encrypt needs 4 input descriptors (config, key, header+aad, plaintext) and
+// 2 output descriptors (ciphertext, tag). Decrypt needs 5 input (+ expected tag).
+const MAX_DESCRIPTOR_CHAIN_LEN: usize = 6;
 
 pub struct Nrf54l15Cal {
     // FIXME: No need to enable and take ownership of everything
@@ -220,9 +222,14 @@ impl Nrf54l15Cal {
                     w.set_startpush(true)
                 });
 
-                // Wait
-                while dma.status().read().fetchbusy() {}
-                while dma.status().read().pushbusy() {}
+                // Wait for all three busy bits to clear, matching REG_STATUS_BUSY_MASK
+                // from the Nordic SDK: FETCHER_BUSY (0x01) | PUSHER_BUSY (0x02) |
+                // PUSHER_WAITING_FIFO (0x20). Without PUSHER_WAITING_FIFO the output
+                // buffers may not be fully written when we return.
+                while {
+                    let s = dma.status().read();
+                    s.fetchbusy() || s.pushbusy() || s.pushwaitingfifo()
+                } {}
             });
         });
     }

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -7,7 +7,7 @@ mod try_rng;
 use descriptor::{DescriptorChain, Input, Output};
 use nrf_pac::{cracen, cracencore};
 
-// CCM-256 encrypt needs 4 input descriptors (config, key, header+aad, plaintext) and
+// CCM encrypt needs 4 input descriptors (config, key, header+aad, plaintext) and
 // 2 output descriptors (ciphertext, tag). Decrypt needs 5 input (+ expected tag).
 const MAX_DESCRIPTOR_CHAIN_LEN: usize = 6;
 
@@ -16,17 +16,12 @@ pub struct Nrf54l15Cal {
     // it's possible to have a more granular ownership
     cracen: cracen::Cracen,
     cracen_core: cracencore::Cracencore,
-    ccm: nrf_pac::ccm::Ccm,
 }
 
 impl embedded_cal::Cal for Nrf54l15Cal {}
 
 impl Nrf54l15Cal {
-    pub fn new(
-        cracen: cracen::Cracen,
-        cracen_core: cracencore::Cracencore,
-        ccm: nrf_pac::ccm::Ccm,
-    ) -> Self {
+    pub fn new(cracen: cracen::Cracen, cracen_core: cracencore::Cracencore) -> Self {
         // Enable cryptomaster
         cracen.enable().write(|w| {
             w.set_cryptomaster(true);
@@ -47,7 +42,6 @@ impl Nrf54l15Cal {
         Self {
             cracen,
             cracen_core,
-            ccm,
         }
     }
 }

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -11,6 +11,7 @@ impl embedded_cal_software_demo::ExtenderConfig for ImplementSha256Short {
 }
 struct TestState {
     cal: embedded_cal_software_demo::Extender<ImplementSha256Short>,
+    raw: embedded_cal_nrf54l15::Nrf54l15Cal,
 }
 
 #[defmt_test::tests]
@@ -20,13 +21,21 @@ mod tests {
 
     #[init]
     fn init() -> super::TestState {
+        let raw = embedded_cal_nrf54l15::Nrf54l15Cal::new(
+            nrf_pac::CRACEN_S,
+            nrf_pac::CRACENCORE_S,
+            nrf_pac::CCM00_S,
+        );
         // FIXME: How to make sure there is a exclusive reference for CRACEN_S?
-        let base =
-            embedded_cal_nrf54l15::Nrf54l15Cal::new(nrf_pac::CRACEN_S, nrf_pac::CRACENCORE_S);
+        let base = embedded_cal_nrf54l15::Nrf54l15Cal::new(
+            nrf_pac::CRACEN_S,
+            nrf_pac::CRACENCORE_S,
+            nrf_pac::CCM00_S,
+        );
 
         let cal = embedded_cal_software_demo::Extender::<ImplementSha256Short>::new(base);
 
-        super::TestState { cal }
+        super::TestState { cal, raw }
     }
 
     #[test]
@@ -53,5 +62,10 @@ mod tests {
     #[test]
     fn test_tryrng(state: &mut super::TestState) {
         embedded_cal::test_tryrng(&mut state.cal);
+    }
+
+    #[test]
+    fn test_aead_aesccm_16_64_128(state: &mut super::TestState) {
+        testvectors::test_aead_aesccm_16_64_128(&mut state.raw);
     }
 }

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -21,17 +21,10 @@ mod tests {
 
     #[init]
     fn init() -> super::TestState {
-        let raw = embedded_cal_nrf54l15::Nrf54l15Cal::new(
-            nrf_pac::CRACEN_S,
-            nrf_pac::CRACENCORE_S,
-            nrf_pac::CCM00_S,
-        );
+        let raw = embedded_cal_nrf54l15::Nrf54l15Cal::new(nrf_pac::CRACEN_S, nrf_pac::CRACENCORE_S);
         // FIXME: How to make sure there is a exclusive reference for CRACEN_S?
-        let base = embedded_cal_nrf54l15::Nrf54l15Cal::new(
-            nrf_pac::CRACEN_S,
-            nrf_pac::CRACENCORE_S,
-            nrf_pac::CCM00_S,
-        );
+        let base =
+            embedded_cal_nrf54l15::Nrf54l15Cal::new(nrf_pac::CRACEN_S, nrf_pac::CRACENCORE_S);
 
         let cal = embedded_cal_software_demo::Extender::<ImplementSha256Short>::new(base);
 

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -68,4 +68,9 @@ mod tests {
     fn test_aead_aesccm_16_64_128(state: &mut super::TestState) {
         testvectors::test_aead_aesccm_16_64_128(&mut state.raw);
     }
+
+    #[test]
+    fn test_aead_aesccm_16_64_256(state: &mut super::TestState) {
+        testvectors::test_aead_aesccm_16_64_256(&mut state.raw);
+    }
 }

--- a/embedded-cal-stm32wba55/src/aead.rs
+++ b/embedded-cal-stm32wba55/src/aead.rs
@@ -1,35 +1,365 @@
-// FIXME: Something is probably there, just not implemented yet.
-//
-// (This would be more concise
-// <https://github.com/lake-rs/embedded-cal/issues/40> is addressed).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AeadAlgorithm {
+    AesCcm16_64_128,
+    AesCcm16_64_256,
+}
+
+impl embedded_cal::AeadAlgorithm for AeadAlgorithm {
+    fn key_length(&self) -> usize {
+        match self {
+            AeadAlgorithm::AesCcm16_64_128 => 16,
+            AeadAlgorithm::AesCcm16_64_256 => 32,
+        }
+    }
+
+    fn tag_length(&self) -> usize {
+        8
+    }
+
+    fn nonce_length(&self) -> usize {
+        13
+    }
+
+    fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
+        match number.into() {
+            10 => Some(AeadAlgorithm::AesCcm16_64_128),
+            11 => Some(AeadAlgorithm::AesCcm16_64_256),
+            _ => None,
+        }
+    }
+}
+
+pub enum AeadKey {
+    AesCcm16_64_128([u8; 16]),
+    AesCcm16_64_256([u8; 32]),
+}
+
+pub enum AeadTag {
+    AesCcm16_64_128([u8; 8]),
+    AesCcm16_64_256([u8; 8]),
+}
+
+impl AsRef<[u8]> for AeadTag {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            AeadTag::AesCcm16_64_128(r) => r,
+            AeadTag::AesCcm16_64_256(r) => r,
+        }
+    }
+}
+
+/// Feed one 16-byte block into the AES DINR and wait for CCF, then clear it.
+fn feed_block(aes: &stm32_metapac::aes::Aes, block: &[u8; 16]) {
+    for i in 0..4 {
+        aes.dinr().write_value(u32::from_be_bytes([
+            block[i * 4],
+            block[i * 4 + 1],
+            block[i * 4 + 2],
+            block[i * 4 + 3],
+        ]));
+    }
+    while !aes.isr().read().ccf() {}
+    aes.isr().write(|w| w.set_ccf(true));
+}
+
+/// Build the CCM B0 block.
+///
+/// B0 = flags | nonce | Q, where Q is the message length encoded in L bytes.
+fn build_b0(nonce: &[u8], msg_len: usize, a_len: usize, tag_len: usize) -> [u8; 16] {
+    let mut b0 = [0u8; 16];
+    let l = 15 - nonce.len();
+    b0[0] = ((l - 1) as u8) | (((tag_len - 2) / 2) as u8) << 3;
+    if a_len > 0 {
+        b0[0] |= 0x40;
+    }
+    b0[1..1 + nonce.len()].copy_from_slice(nonce);
+    let msg_len_bytes = (msg_len as u64).to_be_bytes();
+    b0[16 - l..].copy_from_slice(&msg_len_bytes[8 - l..]);
+    b0
+}
+
+/// Write a 16-byte block into AES_IVR3..AES_IVR0 (MSB-first, big-endian words).
+fn write_ivr(aes: &stm32_metapac::aes::Aes, block: &[u8; 16]) {
+    aes.ivr(3)
+        .write_value(u32::from_be_bytes([block[0], block[1], block[2], block[3]]));
+    aes.ivr(2)
+        .write_value(u32::from_be_bytes([block[4], block[5], block[6], block[7]]));
+    aes.ivr(1).write_value(u32::from_be_bytes([
+        block[8], block[9], block[10], block[11],
+    ]));
+    aes.ivr(0).write_value(u32::from_be_bytes([
+        block[12], block[13], block[14], block[15],
+    ]));
+}
+
+/// Write a 128-bit key into AES_KEYR3..AES_KEYR0 (MSB-first, big-endian words).
+fn write_key_128(aes: &stm32_metapac::aes::Aes, key: &[u8; 16]) {
+    aes.keyr(3)
+        .write_value(u32::from_be_bytes([key[0], key[1], key[2], key[3]]));
+    aes.keyr(2)
+        .write_value(u32::from_be_bytes([key[4], key[5], key[6], key[7]]));
+    aes.keyr(1)
+        .write_value(u32::from_be_bytes([key[8], key[9], key[10], key[11]]));
+    aes.keyr(0)
+        .write_value(u32::from_be_bytes([key[12], key[13], key[14], key[15]]));
+}
+
+/// Run the CCM final phase: set GCMPH, wait for CCF, drain DOUTR, clear CCF, disable EN.
+/// Returns the raw 16-byte authentication tag produced by the hardware.
+fn run_final_phase(aes: &stm32_metapac::aes::Aes) -> [u8; 16] {
+    use stm32_metapac::aes::vals::Gcmph;
+    aes.cr().modify(|w| w.set_gcmph(Gcmph::FINAL_PHASE));
+    while !aes.isr().read().ccf() {}
+
+    let mut tag_full = [0u8; 16];
+    for i in 0..4 {
+        let word: u32 = aes.doutr().read();
+        tag_full[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    aes.isr().write(|w| w.set_ccf(true));
+    aes.cr().modify(|w| w.set_en(false));
+    tag_full
+}
+
+/// Write a 16-byte block to AES_DINR, wait for CCF, read the output from AES_DOUTR,
+/// clear CCF, and return the output block.
+fn exchange_block(aes: &stm32_metapac::aes::Aes, block: &[u8; 16]) -> [u8; 16] {
+    for i in 0..4 {
+        aes.dinr().write_value(u32::from_be_bytes([
+            block[i * 4],
+            block[i * 4 + 1],
+            block[i * 4 + 2],
+            block[i * 4 + 3],
+        ]));
+    }
+    while !aes.isr().read().ccf() {}
+
+    let mut out = [0u8; 16];
+    for i in 0..4 {
+        let word: u32 = aes.doutr().read();
+        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    aes.isr().write(|w| w.set_ccf(true));
+    out
+}
+
+/// Run the CCM payload phase: set GCMPH, enable, and process message in place.
+/// When `with_npblb` is true (decryption), sets NPBLB on the last partial block so the
+/// hardware zeros padding bytes before feeding them into the CBC-MAC.
+fn run_payload_phase(aes: &stm32_metapac::aes::Aes, message: &mut [u8], with_npblb: bool) {
+    use stm32_metapac::aes::vals::Gcmph;
+    aes.cr().modify(|w| w.set_gcmph(Gcmph::PAYLOAD_PHASE));
+    aes.cr().modify(|w| w.set_en(true));
+
+    let msg_len = message.len();
+    let mut msg_offset = 0;
+    while msg_offset < msg_len {
+        let mut block = [0u8; 16];
+        let chunk = (msg_len - msg_offset).min(16);
+        block[..chunk].copy_from_slice(&message[msg_offset..msg_offset + chunk]);
+
+        if with_npblb {
+            let is_last = msg_offset + chunk >= msg_len;
+            if is_last && chunk < 16 {
+                aes.cr().modify(|w| w.set_npblb((16 - chunk) as u8));
+            }
+        }
+
+        let out = exchange_block(aes, &block);
+        message[msg_offset..msg_offset + chunk].copy_from_slice(&out[..chunk]);
+        msg_offset += chunk;
+    }
+}
+
+/// Run the CCM init phase for a 128-bit key: configure AES_CR, load B0 and key,
+/// enable the peripheral, and wait for the first mask computation to complete.
+fn run_init_phase_128(
+    aes: &stm32_metapac::aes::Aes,
+    mode: stm32_metapac::aes::vals::Mode,
+    nonce: &[u8],
+    msg_len: usize,
+    a_len: usize,
+    tag_len: usize,
+    key: &[u8; 16],
+) {
+    use stm32_metapac::aes::vals::{Chmod, Datatype, Gcmph};
+    aes.cr().modify(|w| w.set_en(false));
+    aes.cr().modify(|w| {
+        w.set_chmod(Chmod::CCM);
+        w.set_datatype(Datatype::NONE);
+        w.set_keysize(false); // 128-bit key
+        w.set_mode(mode);
+        w.set_kmod(0x00);
+        w.set_gcmph(Gcmph::INIT_PHASE);
+        w.set_npblb(0); // clear stale NPBLB from any previous operation
+    });
+
+    write_ivr(aes, &build_b0(nonce, msg_len, a_len, tag_len));
+    write_key_128(aes, key);
+
+    while !aes.sr().read().keyvalid() {}
+    aes.cr().modify(|w| w.set_en(true));
+    while !aes.isr().read().ccf() {}
+    aes.isr().write(|w| w.set_ccf(true));
+}
+
+/// Run the CCM header phase: feed [len_hi, len_lo, aad...] in 16-byte blocks.
+/// Must be called only when a_len > 0 (i.e. there is AAD to authenticate).
+fn run_header_phase(
+    aes: &stm32_metapac::aes::Aes,
+    aad: impl embedded_cal::AadGenerator,
+    a_len: usize,
+) {
+    use stm32_metapac::aes::vals::Gcmph;
+    aes.cr().modify(|w| w.set_gcmph(Gcmph::HEADER_PHASE));
+    aes.cr().modify(|w| w.set_en(true));
+
+    let mut block = [0u8; 16];
+    // 2-byte length encoding (covers a_len < 0xFF00)
+    block[0] = (a_len >> 8) as u8;
+    block[1] = (a_len & 0xFF) as u8;
+    let mut pos = 2usize;
+
+    for slice in aad.items() {
+        let mut slice_offset = 0;
+        while slice_offset < slice.len() {
+            let n = (slice.len() - slice_offset).min(16 - pos);
+            block[pos..pos + n].copy_from_slice(&slice[slice_offset..slice_offset + n]);
+            pos += n;
+            slice_offset += n;
+            if pos == 16 {
+                feed_block(aes, &block);
+                block = [0u8; 16];
+                pos = 0;
+            }
+        }
+    }
+    if pos > 0 {
+        // Partial last block, already zero-padded by array initialization.
+        feed_block(aes, &block);
+    }
+}
 
 impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
-    type Algorithm = embedded_cal::empty::NoAlgorithms;
-    type Key = embedded_cal::empty::NoAlgorithms;
-    type Tag = embedded_cal::empty::NoAlgorithms;
+    type Algorithm = AeadAlgorithm;
+    type Key = AeadKey;
+    type Tag = AeadTag;
 
-    fn load_from_keydata(&mut self, alg: Self::Algorithm, _key: &[u8]) -> Self::Key {
-        match alg {}
+    fn load_from_keydata(&mut self, alg: Self::Algorithm, key: &[u8]) -> Self::Key {
+        match alg {
+            AeadAlgorithm::AesCcm16_64_128 => {
+                AeadKey::AesCcm16_64_128(key.try_into().expect("key length mismatch"))
+            }
+            AeadAlgorithm::AesCcm16_64_256 => {
+                AeadKey::AesCcm16_64_256(key.try_into().expect("key length mismatch"))
+            }
+        }
     }
 
     fn encrypt_in_place(
         &mut self,
         key: &Self::Key,
-        _nonce: &[u8],
-        _message: &mut [u8],
-        _aad: impl embedded_cal::AadGenerator,
+        nonce: &[u8],
+        message: &mut [u8],
+        aad: impl embedded_cal::AadGenerator,
     ) -> Self::Tag {
-        match *key {}
+        use stm32_metapac::aes::vals::Mode;
+
+        match key {
+            AeadKey::AesCcm16_64_128(key_bytes) => {
+                // Follows the "CCM encryption and decryption process" from RM0493 (STM32WBA5x
+                // Reference Manual), which runs four sequential hardware phases:
+                // init → header → payload → final.
+                const TAG_LEN: usize = 8;
+                let aes = &self.aes;
+
+                // Total AAD length is needed for B0 Adata flag and B1 length prefix.
+                let a_len: usize = aad.items().map(|s| s.len()).sum();
+
+                // init phase
+                run_init_phase_128(
+                    aes,
+                    Mode::MODE1,
+                    nonce,
+                    message.len(),
+                    a_len,
+                    TAG_LEN,
+                    key_bytes,
+                );
+
+                // header phase
+                if a_len > 0 {
+                    run_header_phase(aes, aad, a_len);
+                }
+
+                // payload phase
+                run_payload_phase(aes, message, false);
+
+                // final phase
+                let tag_full = run_final_phase(aes);
+
+                let mut tag = [0u8; TAG_LEN];
+                tag.copy_from_slice(&tag_full[..TAG_LEN]);
+                AeadTag::AesCcm16_64_128(tag)
+            }
+            AeadKey::AesCcm16_64_256(_) => todo!(),
+        }
     }
 
     fn decrypt_in_place(
         &mut self,
         key: &Self::Key,
-        _nonce: &[u8],
-        _message: &mut [u8],
-        _tag: &[u8],
-        _aad: impl embedded_cal::AadGenerator,
+        nonce: &[u8],
+        message: &mut [u8],
+        tag: &[u8],
+        aad: impl embedded_cal::AadGenerator,
     ) -> Result<(), embedded_cal::DecryptionFailed> {
-        match *key {}
+        use stm32_metapac::aes::vals::Mode;
+
+        match key {
+            AeadKey::AesCcm16_64_128(key_bytes) => {
+                const TAG_LEN: usize = 8;
+                let aes = &self.aes;
+
+                let a_len: usize = aad.items().map(|s| s.len()).sum();
+
+                // init phase
+                run_init_phase_128(
+                    aes,
+                    Mode::MODE3,
+                    nonce,
+                    message.len(),
+                    a_len,
+                    TAG_LEN,
+                    key_bytes,
+                );
+
+                // header phase
+                if a_len > 0 {
+                    run_header_phase(aes, aad, a_len);
+                }
+
+                // payload phase
+                run_payload_phase(aes, message, true);
+
+                // final phase
+                let tag_full = run_final_phase(aes);
+
+                let computed = &tag_full[..TAG_LEN];
+                let tags_match = computed.len() == tag.len()
+                    && computed
+                        .iter()
+                        .zip(tag.iter())
+                        .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+                        == 0;
+
+                if tags_match {
+                    Ok(())
+                } else {
+                    Err(embedded_cal::DecryptionFailed)
+                }
+            }
+            AeadKey::AesCcm16_64_256(_) => todo!(),
+        }
     }
 }

--- a/embedded-cal-stm32wba55/src/aead.rs
+++ b/embedded-cal-stm32wba55/src/aead.rs
@@ -92,6 +92,26 @@ fn write_ivr(aes: &stm32_metapac::aes::Aes, block: &[u8; 16]) {
     ]));
 }
 
+/// Write a 256-bit key into AES_KEYR7..AES_KEYR0 (MSB-first, big-endian words).
+fn write_key_256(aes: &stm32_metapac::aes::Aes, key: &[u8; 32]) {
+    aes.keyr(7)
+        .write_value(u32::from_be_bytes([key[0], key[1], key[2], key[3]]));
+    aes.keyr(6)
+        .write_value(u32::from_be_bytes([key[4], key[5], key[6], key[7]]));
+    aes.keyr(5)
+        .write_value(u32::from_be_bytes([key[8], key[9], key[10], key[11]]));
+    aes.keyr(4)
+        .write_value(u32::from_be_bytes([key[12], key[13], key[14], key[15]]));
+    aes.keyr(3)
+        .write_value(u32::from_be_bytes([key[16], key[17], key[18], key[19]]));
+    aes.keyr(2)
+        .write_value(u32::from_be_bytes([key[20], key[21], key[22], key[23]]));
+    aes.keyr(1)
+        .write_value(u32::from_be_bytes([key[24], key[25], key[26], key[27]]));
+    aes.keyr(0)
+        .write_value(u32::from_be_bytes([key[28], key[29], key[30], key[31]]));
+}
+
 /// Write a 128-bit key into AES_KEYR3..AES_KEYR0 (MSB-first, big-endian words).
 fn write_key_128(aes: &stm32_metapac::aes::Aes, key: &[u8; 16]) {
     aes.keyr(3)
@@ -169,6 +189,37 @@ fn run_payload_phase(aes: &stm32_metapac::aes::Aes, message: &mut [u8], with_npb
         message[msg_offset..msg_offset + chunk].copy_from_slice(&out[..chunk]);
         msg_offset += chunk;
     }
+}
+
+/// Run the CCM init phase for a 256-bit key.
+fn run_init_phase_256(
+    aes: &stm32_metapac::aes::Aes,
+    mode: stm32_metapac::aes::vals::Mode,
+    nonce: &[u8],
+    msg_len: usize,
+    a_len: usize,
+    tag_len: usize,
+    key: &[u8; 32],
+) {
+    use stm32_metapac::aes::vals::{Chmod, Datatype, Gcmph};
+    aes.cr().modify(|w| w.set_en(false));
+    aes.cr().modify(|w| {
+        w.set_chmod(Chmod::CCM);
+        w.set_datatype(Datatype::NONE);
+        w.set_keysize(true); // 256-bit key
+        w.set_mode(mode);
+        w.set_kmod(0x00);
+        w.set_gcmph(Gcmph::INIT_PHASE);
+        w.set_npblb(0);
+    });
+
+    write_ivr(aes, &build_b0(nonce, msg_len, a_len, tag_len));
+    write_key_256(aes, key);
+
+    while !aes.sr().read().keyvalid() {}
+    aes.cr().modify(|w| w.set_en(true));
+    while !aes.isr().read().ccf() {}
+    aes.isr().write(|w| w.set_ccf(true));
 }
 
 /// Run the CCM init phase for a 128-bit key: configure AES_CR, load B0 and key,
@@ -302,7 +353,34 @@ impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
                 tag.copy_from_slice(&tag_full[..TAG_LEN]);
                 AeadTag::AesCcm16_64_128(tag)
             }
-            AeadKey::AesCcm16_64_256(_) => todo!(),
+            AeadKey::AesCcm16_64_256(key_bytes) => {
+                const TAG_LEN: usize = 8;
+                let aes = &self.aes;
+
+                let a_len: usize = aad.items().map(|s| s.len()).sum();
+
+                run_init_phase_256(
+                    aes,
+                    Mode::MODE1,
+                    nonce,
+                    message.len(),
+                    a_len,
+                    TAG_LEN,
+                    key_bytes,
+                );
+
+                if a_len > 0 {
+                    run_header_phase(aes, aad, a_len);
+                }
+
+                run_payload_phase(aes, message, false);
+
+                let tag_full = run_final_phase(aes);
+
+                let mut tag = [0u8; TAG_LEN];
+                tag.copy_from_slice(&tag_full[..TAG_LEN]);
+                AeadTag::AesCcm16_64_256(tag)
+            }
         }
     }
 
@@ -359,7 +437,44 @@ impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
                     Err(embedded_cal::DecryptionFailed)
                 }
             }
-            AeadKey::AesCcm16_64_256(_) => todo!(),
+            AeadKey::AesCcm16_64_256(key_bytes) => {
+                const TAG_LEN: usize = 8;
+                let aes = &self.aes;
+
+                let a_len: usize = aad.items().map(|s| s.len()).sum();
+
+                run_init_phase_256(
+                    aes,
+                    Mode::MODE3,
+                    nonce,
+                    message.len(),
+                    a_len,
+                    TAG_LEN,
+                    key_bytes,
+                );
+
+                if a_len > 0 {
+                    run_header_phase(aes, aad, a_len);
+                }
+
+                run_payload_phase(aes, message, true);
+
+                let tag_full = run_final_phase(aes);
+
+                let computed = &tag_full[..TAG_LEN];
+                let tags_match = computed.len() == tag.len()
+                    && computed
+                        .iter()
+                        .zip(tag.iter())
+                        .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+                        == 0;
+
+                if tags_match {
+                    Ok(())
+                } else {
+                    Err(embedded_cal::DecryptionFailed)
+                }
+            }
         }
     }
 }

--- a/embedded-cal-stm32wba55/src/aead.rs
+++ b/embedded-cal-stm32wba55/src/aead.rs
@@ -62,22 +62,6 @@ fn feed_block(aes: &stm32_metapac::aes::Aes, block: &[u8; 16]) {
     aes.isr().write(|w| w.set_ccf(true));
 }
 
-/// Build the CCM B0 block.
-///
-/// B0 = flags | nonce | Q, where Q is the message length encoded in L bytes.
-fn build_b0(nonce: &[u8], msg_len: usize, a_len: usize, tag_len: usize) -> [u8; 16] {
-    let mut b0 = [0u8; 16];
-    let l = 15 - nonce.len();
-    b0[0] = ((l - 1) as u8) | (((tag_len - 2) / 2) as u8) << 3;
-    if a_len > 0 {
-        b0[0] |= 0x40;
-    }
-    b0[1..1 + nonce.len()].copy_from_slice(nonce);
-    let msg_len_bytes = (msg_len as u64).to_be_bytes();
-    b0[16 - l..].copy_from_slice(&msg_len_bytes[8 - l..]);
-    b0
-}
-
 /// Write a 16-byte block into AES_IVR3..AES_IVR0 (MSB-first, big-endian words).
 fn write_ivr(aes: &stm32_metapac::aes::Aes, block: &[u8; 16]) {
     aes.ivr(3)
@@ -213,7 +197,7 @@ fn run_init_phase_256(
         w.set_npblb(0);
     });
 
-    write_ivr(aes, &build_b0(nonce, msg_len, a_len, tag_len));
+    write_ivr(aes, &embedded_cal::build_b0(nonce, msg_len, a_len, tag_len));
     write_key_256(aes, key);
 
     while !aes.sr().read().keyvalid() {}
@@ -245,7 +229,7 @@ fn run_init_phase_128(
         w.set_npblb(0); // clear stale NPBLB from any previous operation
     });
 
-    write_ivr(aes, &build_b0(nonce, msg_len, a_len, tag_len));
+    write_ivr(aes, &embedded_cal::build_b0(nonce, msg_len, a_len, tag_len));
     write_key_128(aes, key);
 
     while !aes.sr().read().keyvalid() {}

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -2,7 +2,7 @@
 
 use embedded_cal::plumbing::hash::SHA2SHORT_BLOCK_SIZE;
 use stm32_metapac::{
-    hash,
+    aes, hash,
     rcc::{self, vals::Rngsel},
     rng::{
         self,
@@ -23,22 +23,29 @@ pub struct Stm32wba55Cal {
     hash: hash::Hash,
     rcc: rcc::Rcc,
     rng: rng::Rng,
+    aes: aes::Aes,
 }
 
 impl embedded_cal::Cal for Stm32wba55Cal {}
 
 impl Stm32wba55Cal {
-    pub fn new(hash: hash::Hash, rcc: rcc::Rcc, rng: rng::Rng) -> Self {
+    pub fn new(hash: hash::Hash, rcc: rcc::Rcc, rng: rng::Rng, aes: aes::Aes) -> Self {
         // Select HSI as the RNG kernel clock source (default is LSE which may not be running)
         rcc.ccipr2().modify(|w| w.set_rngsel(Rngsel::HSI));
 
-        // Enable HASH and RNG clocks
+        // Enable HASH, RNG, and AES clocks
         rcc.ahb2enr().modify(|w| {
             w.set_hashen(true);
             w.set_rngen(true);
+            w.set_aesen(true);
         });
 
-        let mut cal = Self { hash, rcc, rng };
+        let mut cal = Self {
+            hash,
+            rcc,
+            rng,
+            aes,
+        };
         cal.init_rng();
         cal
     }
@@ -106,8 +113,11 @@ fn wait_for(mut condition: impl FnMut() -> bool) {
 
 impl Drop for Stm32wba55Cal {
     fn drop(&mut self) {
-        // Disable HASH clock
-        self.rcc.ahb2enr().modify(|w| w.set_hashen(false));
+        self.rcc.ahb2enr().modify(|w| {
+            w.set_hashen(false);
+            w.set_rngen(false);
+            w.set_aesen(false);
+        });
         self.rng.cr().modify(|w| w.set_rngen(false));
     }
 }

--- a/embedded-cal-stm32wba55/tests/integration.rs
+++ b/embedded-cal-stm32wba55/tests/integration.rs
@@ -74,4 +74,9 @@ mod tests {
     fn test_aead_aesccm_16_64_128(state: &mut super::TestState) {
         testvectors::test_aead_aesccm_16_64_128(&mut state.raw);
     }
+
+    #[test]
+    fn test_aead_aesccm_16_64_256(state: &mut super::TestState) {
+        testvectors::test_aead_aesccm_16_64_256(&mut state.raw);
+    }
 }

--- a/embedded-cal-stm32wba55/tests/integration.rs
+++ b/embedded-cal-stm32wba55/tests/integration.rs
@@ -30,11 +30,13 @@ mod tests {
             stm32_metapac::HASH,
             stm32_metapac::RCC,
             stm32_metapac::RNG,
+            stm32_metapac::AES,
         );
         let base = embedded_cal_stm32wba55::Stm32wba55Cal::new(
             stm32_metapac::HASH,
             stm32_metapac::RCC,
             stm32_metapac::RNG,
+            stm32_metapac::AES,
         );
 
         let cal = embedded_cal_software_demo::Extender::<ImplementSha256Short>::new(base);
@@ -66,5 +68,10 @@ mod tests {
     #[test]
     fn test_tryrng(state: &mut super::TestState) {
         embedded_cal::test_tryrng(&mut state.cal);
+    }
+
+    #[test]
+    fn test_aead_aesccm_16_64_128(state: &mut super::TestState) {
+        testvectors::test_aead_aesccm_16_64_128(&mut state.raw);
     }
 }

--- a/embedded-cal/src/aead.rs
+++ b/embedded-cal/src/aead.rs
@@ -125,6 +125,22 @@ impl AadGenerator for &[&[u8]] {
     }
 }
 
+/// Build the CCM B0 block as defined in RFC 3610.
+///
+/// B0 = flags | nonce | Q, where Q is the message length encoded in L bytes.
+pub fn build_b0(nonce: &[u8], msg_len: usize, a_len: usize, tag_len: usize) -> [u8; 16] {
+    let mut b0 = [0u8; 16];
+    let l = 15 - nonce.len();
+    b0[0] = ((l - 1) as u8) | (((tag_len - 2) / 2) as u8) << 3;
+    if a_len > 0 {
+        b0[0] |= 0x40;
+    }
+    b0[1..1 + nonce.len()].copy_from_slice(nonce);
+    let msg_len_bytes = (msg_len as u64).to_be_bytes();
+    b0[16 - l..].copy_from_slice(&msg_len_bytes[8 - l..]);
+    b0
+}
+
 pub fn test_aead_algorithm_aesccm_16_64_128<AP: AeadProvider>() {
     let cose_10 = AP::Algorithm::from_cose_number(10i8).expect(
         "test for type claiming AES-CCM-16-64-128 compatibility did not recognize COSE number 10",

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -12,7 +12,7 @@ mod rng;
 pub mod plumbing;
 
 pub use aead::{
-    AadGenerator, AeadAlgorithm, AeadProvider, DecryptionFailed,
+    AadGenerator, AeadAlgorithm, AeadProvider, DecryptionFailed, build_b0,
     test_aead_algorithm_aesccm_16_64_128,
 };
 pub use dh::{


### PR DESCRIPTION
built on top of #59 

nRF54L15 has a CCM00 chip that is dedicated for AES-CCM, but sadly it only works for 128bit key.

For 256bit key, we had to use CRACEN (this PR)

I can see 2 paths from here:

1. continue like this (CCM00 for 128bit key, CRACEN for 256bit keys)
2. unify to use CRACEN for every AES-CCM.