### PR TITLE
RNG: Expect (but do not require) infallible RNG

### DIFF
--- a/embedded-cal-libcrux/src/empty_impls.rs
+++ b/embedded-cal-libcrux/src/empty_impls.rs
@@ -66,10 +66,7 @@ impl<EC: ExtenderConfig> embedded_cal::DhProvider for Extender<EC> {
     type PublicKey = embedded_cal::empty::NoAlgorithms;
     type SharedSecret = embedded_cal::empty::NoAlgorithms;
 
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey>
-    where
-        Self: rand_core::TryRng,
-    {
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
         match alg {}
     }
 

--- a/embedded-cal-nrf54l15/src/empty_impls.rs
+++ b/embedded-cal-nrf54l15/src/empty_impls.rs
@@ -7,7 +7,7 @@ impl embedded_cal::DhProvider for Nrf54l15Cal {
     type PublicKey = embedded_cal::empty::NoAlgorithms;
     type SharedSecret = embedded_cal::empty::NoAlgorithms;
 
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey> {
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
         match alg {}
     }
 

--- a/embedded-cal-nrf54l15/src/try_rng.rs
+++ b/embedded-cal-nrf54l15/src/try_rng.rs
@@ -2,29 +2,9 @@ use crate::Nrf54l15Cal;
 use nrf_pac::cracencore::vals::{ControlSoftrst, State};
 const MAX_TRNG_RESTARTS: u32 = 3;
 
-/// Error returned by [`RngProvider::try_fill_bytes`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RngError {
-    /// The hardware noise source failed its internal health test too many times.
-    ///
-    /// This indicates the entropy source may be untrustworthy (degraded oscillator,
-    /// power instability, or a silicon fault).
-    HardwareFailure,
-}
-
-impl core::fmt::Display for RngError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            RngError::HardwareFailure => write!(f, "hardware noise source failed health test"),
-        }
-    }
-}
-
-impl core::error::Error for RngError {}
-
 impl rand_core::TryCryptoRng for Nrf54l15Cal {}
 impl rand_core::TryRng for Nrf54l15Cal {
-    type Error = RngError;
+    type Error = core::convert::Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut bytes = [0u8; 4];
@@ -54,13 +34,14 @@ impl rand_core::TryRng for Nrf54l15Cal {
             //
             // Unlike transient startup/fill states (RESET, STARTUP, FILLFIFO),
             // ERROR indicates the noise source itself may be untrustworthy, so
-            // we bound restarts: after MAX_TRNG_RESTARTS we return Err(HardwareFailure)
-            // rather than looping forever or handing out potentially non-random bytes.
+            // we bound restarts: after MAX_TRNG_RESTARTS we assume the hardware
+            // is faulty or has been tampered with, rather than looping forever
+            // or handing out potentially non-random bytes.
             let fsm = self.cracen_core.rngcontrol().status().read().state();
             if fsm == State::ERROR {
                 restarts += 1;
                 if restarts > MAX_TRNG_RESTARTS {
-                    return Err(RngError::HardwareFailure);
+                    panic!("RNG hardware failure");
                 }
 
                 // Pulse softrst to flush the conditioner and FIFO

--- a/embedded-cal-rustcrypto/src/dh.rs
+++ b/embedded-cal-rustcrypto/src/dh.rs
@@ -185,25 +185,22 @@ pub struct SharedSecret(heapless::Vec<u8, MAX_SHARED_SECRET_LENGTH>);
 
 struct OldRng<'c, C: embedded_cal::Cal>(&'c mut C);
 
-impl<'c, C: embedded_cal::Cal + rand_core::TryCryptoRng> rand_core_06::CryptoRng for OldRng<'c, C> {}
-impl<'c, C: embedded_cal::Cal + rand_core::TryCryptoRng> rand_core_06::RngCore for OldRng<'c, C> {
+impl<'c, C: embedded_cal::Cal + rand_core::CryptoRng> rand_core_06::CryptoRng for OldRng<'c, C> {}
+impl<'c, C: embedded_cal::Cal + rand_core::CryptoRng> rand_core_06::RngCore for OldRng<'c, C> {
     fn next_u32(&mut self) -> u32 {
-        self.0.try_next_u32().unwrap()
+        self.0.next_u32()
     }
 
     fn next_u64(&mut self) -> u64 {
-        self.0.try_next_u64().unwrap()
+        self.0.next_u64()
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.0.try_fill_bytes(dest).unwrap()
+        self.0.fill_bytes(dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
-        self.0.try_fill_bytes(dest).map_err(|_| {
-            rand_core_06::Error::from(
-                core::num::NonZero::try_from(rand_core_06::Error::CUSTOM_START).unwrap(),
-            )
-        })
+        self.0.fill_bytes(dest);
+        Ok(())
     }
 }

--- a/embedded-cal-rustcrypto/src/dh.rs
+++ b/embedded-cal-rustcrypto/src/dh.rs
@@ -9,14 +9,14 @@ impl embedded_cal::DhProvider for RustcryptoCal {
     type PublicKey = PublicKey;
     type SharedSecret = SharedSecret;
 
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey> {
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
         // We're not wrapping anything, so no point in deferring to the self RNG.
-        Some(VisibleSecretKey(match alg {
+        VisibleSecretKey(match alg {
             DhAlgorithm::P256 => SecretKey::P256(p256::SecretKey::random(&mut OldRng(self))),
             DhAlgorithm::X25519 => {
                 SecretKey::X25519(x25519_dalek::StaticSecret::random_from_rng(OldRng(self)))
             }
-        }))
+        })
     }
 
     fn export_secretkey_bytes<'s>(

--- a/embedded-cal-rustcrypto/src/rng.rs
+++ b/embedded-cal-rustcrypto/src/rng.rs
@@ -8,17 +8,18 @@ use super::RustcryptoCal;
 impl rand_core::TryCryptoRng for RustcryptoCal {}
 
 impl rand_core::TryRng for RustcryptoCal {
-    type Error = getrandom::Error;
+    type Error = core::convert::Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-        getrandom::u32()
+        Ok(getrandom::u32().expect("platform RNG failure"))
     }
 
     fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-        getrandom::u64()
+        Ok(getrandom::u64().expect("platform RNG failure"))
     }
 
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-        getrandom::fill(dst)
+        getrandom::fill(dst).expect("platform RNG failure");
+        Ok(())
     }
 }

--- a/embedded-cal-software-demo/src/dh.rs
+++ b/embedded-cal-software-demo/src/dh.rs
@@ -10,12 +10,8 @@ impl<EC: ExtenderConfig> DhProvider for Extender<EC> {
     type PublicKey = <EC::Base as DhProvider>::PublicKey;
     type SharedSecret = <EC::Base as DhProvider>::SharedSecret;
 
-    fn generate_visible(&mut self, _alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey>
-    where
-        Self: rand_core::TryRng,
-    {
-        // pending resolution of https://github.com/lake-rs/embedded-cal/issues/51
-        todo!()
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
+        self.0.generate_visible(alg)
     }
 
     fn shared_secret(

--- a/embedded-cal-software-demo/src/tests/dummy_sha256/empty_impls.rs
+++ b/embedded-cal-software-demo/src/tests/dummy_sha256/empty_impls.rs
@@ -84,7 +84,7 @@ impl embedded_cal::DhProvider for DummySha256 {
     type PublicKey = embedded_cal::empty::NoAlgorithms;
     type SharedSecret = embedded_cal::empty::NoAlgorithms;
 
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey> {
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
         match alg {}
     }
 

--- a/embedded-cal-stm32wba55/src/empty_impls.rs
+++ b/embedded-cal-stm32wba55/src/empty_impls.rs
@@ -7,7 +7,7 @@ impl embedded_cal::DhProvider for Stm32wba55Cal {
     type PublicKey = embedded_cal::empty::NoAlgorithms;
     type SharedSecret = embedded_cal::empty::NoAlgorithms;
 
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey> {
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
         match alg {}
     }
 

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -39,7 +39,7 @@ impl Stm32wba55Cal {
         });
 
         let mut cal = Self { hash, rcc, rng };
-        cal.init_rng().expect("RNG init failed");
+        cal.init_rng();
         cal
     }
 
@@ -48,7 +48,7 @@ impl Stm32wba55Cal {
     /// Must be called once after enabling the RNG clock, and again on seed error recovery.
     /// Uses NIST config A (certifiable). The HTCR magic number must precede any HTCR write
     /// per the RM0493 requirement.
-    fn init_rng(&mut self) -> Result<(), try_rng::RngError> {
+    fn init_rng(&mut self) {
         // Enter conditioning reset with NIST config A settings
         self.rng.cr().write(|w| {
             w.set_condrst(true);
@@ -63,7 +63,7 @@ impl Stm32wba55Cal {
         });
 
         // Wait for conditioning reset to take effect
-        wait_for(|| self.rng.cr().read().condrst())?;
+        wait_for(|| self.rng.cr().read().condrst());
 
         // Write health test config: magic number must immediately precede the actual value
         self.rng.htcr().write(|w| w.set_htcfg(Htcfg::MAGIC));
@@ -76,7 +76,7 @@ impl Stm32wba55Cal {
         });
 
         // Wait for conditioning reset to deassert (RM0493 requires waiting for both assert and deassert)
-        wait_for(|| !self.rng.cr().read().condrst())?;
+        wait_for(|| !self.rng.cr().read().condrst());
 
         // Clear any latched seed error from the reset
         self.rng.sr().modify(|w| w.set_seis(false));
@@ -86,24 +86,22 @@ impl Stm32wba55Cal {
         wait_for(|| {
             let sr = self.rng.sr().read();
             sr.drdy() || sr.seis()
-        })?;
+        });
         if self.rng.sr().read().seis() {
-            return Err(try_rng::RngError::HardwareFailure);
+            panic!("RNG hardware error");
         }
         let _ = self.rng.dr().read();
-
-        Ok(())
     }
 }
 
-fn wait_for(mut condition: impl FnMut() -> bool) -> Result<(), try_rng::RngError> {
+fn wait_for(mut condition: impl FnMut() -> bool) {
     for _ in 0..1000 {
         if condition() {
-            return Ok(());
+            return;
         }
         core::hint::spin_loop();
     }
-    Err(try_rng::RngError::HardwareFailure)
+    panic!("RNG hardware failure");
 }
 
 impl Drop for Stm32wba55Cal {

--- a/embedded-cal-stm32wba55/src/try_rng.rs
+++ b/embedded-cal-stm32wba55/src/try_rng.rs
@@ -1,29 +1,9 @@
 use crate::Stm32wba55Cal;
 const MAX_SEED_RETRIES: u32 = 3;
 
-/// Error returned by [`RngProvider::try_fill_bytes`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RngError {
-    /// The hardware noise source failed its internal health test too many times.
-    ///
-    /// This indicates the entropy source may be untrustworthy (degraded oscillator,
-    /// power instability, or a silicon fault).
-    HardwareFailure,
-}
-
-impl core::fmt::Display for RngError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            RngError::HardwareFailure => write!(f, "hardware noise source failed health test"),
-        }
-    }
-}
-
-impl core::error::Error for RngError {}
-
 impl rand_core::TryCryptoRng for Stm32wba55Cal {}
 impl rand_core::TryRng for Stm32wba55Cal {
-    type Error = RngError;
+    type Error = core::convert::Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut bytes = [0u8; 4];
@@ -53,14 +33,15 @@ impl rand_core::TryRng for Stm32wba55Cal {
                 // degraded (bad oscillator, power instability, temperature extreme,
                 // or a silicon fault). Re-initializing in that case just loops back
                 // to the same failure, so we bound retries: after MAX_SEED_RETRIES
-                // consecutive seed errors we give up and return Err(()) rather than
-                // spinning forever or handing out potentially non-random bytes.
+                // consecutive seed errors we assume the hardware is faulty or has
+                // been tampered with, rather than spinning forever or handing out
+                // potentially non-random bytes.
                 seed_errors += 1;
                 if seed_errors > MAX_SEED_RETRIES {
-                    return Err(RngError::HardwareFailure);
+                    panic!("RNG hardware failure");
                 }
                 self.rng.sr().modify(|w| w.set_seis(false));
-                self.init_rng()?;
+                self.init_rng();
                 continue;
             }
 

--- a/embedded-cal/src/dh.rs
+++ b/embedded-cal/src/dh.rs
@@ -46,13 +46,13 @@ pub trait DhProvider {
     fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey>
     where
         // FIXME: https://github.com/lake-rs/embedded-cal/issues/51
-        Self: rand_core::TryRng;
+        Self: rand_core::Rng;
 
     /// Generates a secret key.
     fn generate(&mut self, alg: Self::DhAlgorithm) -> Option<Self::SecretKey>
     where
         // FIXME: https://github.com/lake-rs/embedded-cal/issues/51
-        Self: rand_core::TryRng,
+        Self: rand_core::Rng,
     {
         Some(self.generate_visible(alg)?.into())
     }
@@ -187,7 +187,7 @@ pub fn test_dh_algorithm_ecdh_p256<DP: DhProvider>() {
     assert_eq!(cose_ecdh_1.output_length(), 32)
 }
 
-pub fn test_dh_selftest<C: crate::Cal + rand_core::TryCryptoRng>(cal: &mut C, alg: C::DhAlgorithm) {
+pub fn test_dh_selftest<C: crate::Cal + rand_core::CryptoRng>(cal: &mut C, alg: C::DhAlgorithm) {
     let my_secret = cal.generate(alg.clone()).unwrap();
     let peer_secret = cal.generate(alg).unwrap();
     let my_public = cal.public_key(&my_secret);

--- a/embedded-cal/src/dh.rs
+++ b/embedded-cal/src/dh.rs
@@ -43,18 +43,11 @@ pub trait DhProvider {
 
     /// Generates a secret key that is intended to be exported / shared (e.g. to be persisted
     /// across program executions).
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey>
-    where
-        // FIXME: https://github.com/lake-rs/embedded-cal/issues/51
-        Self: rand_core::Rng;
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey;
 
     /// Generates a secret key.
-    fn generate(&mut self, alg: Self::DhAlgorithm) -> Option<Self::SecretKey>
-    where
-        // FIXME: https://github.com/lake-rs/embedded-cal/issues/51
-        Self: rand_core::Rng,
-    {
-        Some(self.generate_visible(alg)?.into())
+    fn generate(&mut self, alg: Self::DhAlgorithm) -> Self::SecretKey {
+        self.generate_visible(alg).into()
     }
 
     /// Exposes a visible secret key's secret.
@@ -188,8 +181,8 @@ pub fn test_dh_algorithm_ecdh_p256<DP: DhProvider>() {
 }
 
 pub fn test_dh_selftest<C: crate::Cal + rand_core::CryptoRng>(cal: &mut C, alg: C::DhAlgorithm) {
-    let my_secret = cal.generate(alg.clone()).unwrap();
-    let peer_secret = cal.generate(alg).unwrap();
+    let my_secret = cal.generate(alg.clone());
+    let peer_secret = cal.generate(alg);
     let my_public = cal.public_key(&my_secret);
     let peer_public = cal.public_key(&peer_secret);
 

--- a/embedded-cal/src/empty.rs
+++ b/embedded-cal/src/empty.rs
@@ -94,10 +94,7 @@ impl<const PLUMBING: bool> DhProvider for EmptyCal<PLUMBING> {
     type PublicKey = NoAlgorithms;
     type SharedSecret = NoAlgorithms;
 
-    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Option<Self::VisibleSecretKey>
-    where
-        Self: rand_core::TryRng,
-    {
+    fn generate_visible(&mut self, alg: Self::DhAlgorithm) -> Self::VisibleSecretKey {
         match alg {}
     }
 

--- a/embedded-cal/src/empty.rs
+++ b/embedded-cal/src/empty.rs
@@ -156,24 +156,6 @@ impl<const PLUMBING: bool> DhProvider for EmptyCal<PLUMBING> {
     }
 }
 
-impl<const PLUMBING: bool> rand_core::TryCryptoRng for EmptyCal<PLUMBING> {}
-
-impl<const PLUMBING: bool> rand_core::TryRng for EmptyCal<PLUMBING> {
-    type Error = NoRng;
-
-    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-        Err(NoRng)
-    }
-
-    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-        Err(NoRng)
-    }
-
-    fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
-        Err(NoRng)
-    }
-}
-
 impl plumbing::Plumbing for EmptyCal<true> {}
 
 impl plumbing::hash::Hash for EmptyCal<true> {}
@@ -244,15 +226,3 @@ impl DhAlgorithm for NoAlgorithms {
         match *self {}
     }
 }
-
-/// Error type returned by [`EmptyCal`] when trying to obtain random numbers.
-#[derive(Debug)]
-pub struct NoRng;
-
-impl core::fmt::Display for NoRng {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("no RNG available in empty Cal implementation")
-    }
-}
-
-impl core::error::Error for NoRng {}


### PR DESCRIPTION
Threading the option of hardware failure all the way through would create a lot of application code that doesn't know how to deal with it -- and why should it, "hardware isn't doing what it should" is irrecoverable and panic-worthy unless we decide differently in https://github.com/lake-rs/embedded-cal/issues/46.

This turns all the cases where we touch RNGs into infallible RNGs. (Note that the impl is still of `TryRng`, as `Rng` has a blanket impl on `Twhere T: TryRng<Error = Infallible>` and thus can and should not be implemented).

It does not yet act on #51 (make Rng a dependency of Cal), because so far things work fine that way (and #40 would make short work of any changes around there anyway).