### PR TITLE
fix: linker scripts

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,12 +40,14 @@ jobs:
       uses: actions/checkout@v5
     - name: Add embedded target
       run: rustup target add thumbv8m.main-none-eabihf
-    - name: cargo check nRF54L15 (lib + tests)
+    - name: Install flip-link
+      run: cargo install flip-link
+    - name: cargo build nRF54L15 (lib + tests)
       working-directory: embedded-cal-nrf54l15
-      run: cargo check --tests
-    - name: cargo check STM32WBA55 (lib + tests)
+      run: cargo build --tests
+    - name: cargo build STM32WBA55 (lib + tests)
       working-directory: embedded-cal-stm32wba55
-      run: cargo check --tests
+      run: cargo build --tests
 
 #   generate-fstar:
 #     runs-on: ubuntu-latest

--- a/embedded-cal-nrf54l15/memory.x
+++ b/embedded-cal-nrf54l15/memory.x
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+/* SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss */
 
 MEMORY
 {

--- a/embedded-cal-stm32wba55/device.x
+++ b/embedded-cal-stm32wba55/device.x
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+/* SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss */
 
 PROVIDE(WWDG = DefaultHandler);
 PROVIDE(PDV = DefaultHandler);

--- a/embedded-cal-stm32wba55/memory.x
+++ b/embedded-cal-stm32wba55/memory.x
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+/* SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss */
 
 MEMORY
 {


### PR DESCRIPTION
The comments on linker scripts should be on the format `/* foo */`

also, changed the CI to build instead of check, so it catches this kind of error in the future