### PR TITLE
sha3 for nRF54L15

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -40,6 +40,10 @@ Limitation in AAD streaming or message size are subject to ongoing work.
 | SHA-256 | software-demo | using SHA2-short plumbing for acceleration |
 | SHA2-short | nrf54l15 | providing plumbing |
 | SHA2-short | stm32wba55 | providing plumbing |
+| SHA3-224 | nrf54l15 | |
+| SHA3-256 | nrf54l15 | |
+| SHA3-384 | nrf54l15 | |
+| SHA3-512 | nrf54l15 | |
 
 # HMAC
 

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -7,6 +7,7 @@ mod descriptor;
 mod dh;
 mod microcode;
 mod sha2;
+mod sha3;
 mod try_rng;
 
 use descriptor::{DescriptorChain, Input, Output};
@@ -30,7 +31,7 @@ pub struct Nrf54l15Cal {
 impl embedded_cal::Cal for Nrf54l15Cal {
     type DhProvider = Self;
     type AeadProvider = Self;
-    type HashProvider = EmptyCal<false>;
+    type HashProvider = Self;
     type HmacProvider = EmptyCal<false>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
@@ -42,7 +43,7 @@ impl embedded_cal::Cal for Nrf54l15Cal {
     }
 
     fn hash(&mut self) -> &mut Self::HashProvider {
-        &mut self.empty
+        self
     }
 
     fn hmac(&mut self) -> &mut Self::HmacProvider {

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -6,6 +6,7 @@ mod aead;
 mod descriptor;
 mod dh;
 mod microcode;
+mod sha2;
 mod try_rng;
 
 use descriptor::{DescriptorChain, Input, Output};
@@ -93,89 +94,6 @@ impl Drop for Nrf54l15Cal {
             w.set_rng(false);
             w.set_pkeikg(false)
         });
-    }
-}
-
-#[derive(Clone)]
-pub struct HashState {
-    // We could instead make this unconditional and then set state (in init) to 0x6a, 0x09, 0xe6,
-    // 0x67, ... (the big-endian version of the SHA256 starting points 0x6a09e667u32), but the
-    // hardware has the values, so why not use them.
-    state: Option<[u8; 32]>,
-}
-
-pub enum HashResult {
-    Sha256([u8; 32]),
-}
-
-impl AsRef<[u8]> for HashResult {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            HashResult::Sha256(r) => &r[..],
-        }
-    }
-}
-
-impl embedded_cal::plumbing::Plumbing for Nrf54l15Cal {}
-
-impl embedded_cal::plumbing::hash::Hash for Nrf54l15Cal {}
-
-impl embedded_cal::plumbing::hash::Sha2Short for Nrf54l15Cal {
-    const SUPPORTED: bool = true;
-    const SEND_PADDING: bool = true;
-    const FIRST_CHUNK_SIZE: usize = 64;
-    const UPDATE_MULTICHUNK: bool = true;
-
-    type State = HashState;
-
-    fn init(&mut self, variant: embedded_cal::plumbing::hash::Sha2ShortVariant) -> Self::State {
-        match variant {
-            embedded_cal::plumbing::hash::Sha2ShortVariant::Sha256 => (),
-            // Although really all we need to support it is probably just copying the requested
-            // length into the output buffer
-            _ => todo!("Unsupported variant"),
-        };
-
-        Self::State { state: None }
-    }
-
-    fn update(&mut self, instance: &mut Self::State, data: &[u8]) {
-        debug_assert!(
-            data.len().is_multiple_of(64),
-            "Chunking requirements laid out in Self::FIRST_CHUNK_SIZE not upheld."
-        );
-
-        let mut new_state: [u8; 32] = [0x00; 32];
-
-        let header: [u8; 4] = [0x08, 0x00, 0x00, 0x00];
-
-        let mut output_descriptors: DescriptorChain<Output, MAX_DESCRIPTOR_CHAIN_LEN> =
-            DescriptorChain::new();
-        output_descriptors.push(&mut new_state, 32);
-
-        let mut input_descriptors: DescriptorChain<Input, MAX_DESCRIPTOR_CHAIN_LEN> =
-            DescriptorChain::new();
-
-        input_descriptors.push(&header, 19);
-
-        if let Some(state) = &instance.state {
-            input_descriptors.push(state, 99);
-        }
-
-        input_descriptors.push(data, 35);
-
-        self.execute_cryptomaster_dma(&mut input_descriptors, &mut output_descriptors);
-
-        instance.state = Some(new_state);
-    }
-
-    fn finalize(&mut self, instance: Self::State, last_chunk: &[u8], target: &mut [u8]) {
-        debug_assert!(
-            last_chunk.is_empty(),
-            "Self::SEND_PADDING=true requires user not to send any last chunk"
-        );
-
-        target.copy_from_slice(&instance.state.unwrap());
     }
 }
 

--- a/embedded-cal-nrf54l15/src/sha2.rs
+++ b/embedded-cal-nrf54l15/src/sha2.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+
+use crate::descriptor::{DescriptorChain, Input, Output};
+
+#[derive(Clone)]
+pub struct HashState {
+    // We could instead make this unconditional and then set state (in init) to 0x6a, 0x09, 0xe6,
+    // 0x67, ... (the big-endian version of the SHA256 starting points 0x6a09e667u32), but the
+    // hardware has the values, so why not use them.
+    state: Option<[u8; 32]>,
+}
+
+pub enum HashResult {
+    Sha256([u8; 32]),
+}
+
+impl AsRef<[u8]> for HashResult {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            HashResult::Sha256(r) => &r[..],
+        }
+    }
+}
+
+impl embedded_cal::plumbing::Plumbing for super::Nrf54l15Cal {}
+
+impl embedded_cal::plumbing::hash::Hash for super::Nrf54l15Cal {}
+
+impl embedded_cal::plumbing::hash::Sha2Short for super::Nrf54l15Cal {
+    const SUPPORTED: bool = true;
+    const SEND_PADDING: bool = true;
+    const FIRST_CHUNK_SIZE: usize = 64;
+    const UPDATE_MULTICHUNK: bool = true;
+
+    type State = HashState;
+
+    fn init(&mut self, variant: embedded_cal::plumbing::hash::Sha2ShortVariant) -> Self::State {
+        match variant {
+            embedded_cal::plumbing::hash::Sha2ShortVariant::Sha256 => (),
+            // Although really all we need to support it is probably just copying the requested
+            // length into the output buffer
+            _ => todo!("Unsupported variant"),
+        };
+
+        Self::State { state: None }
+    }
+
+    fn update(&mut self, instance: &mut Self::State, data: &[u8]) {
+        debug_assert!(
+            data.len().is_multiple_of(64),
+            "Chunking requirements laid out in Self::FIRST_CHUNK_SIZE not upheld."
+        );
+
+        let mut new_state: [u8; 32] = [0x00; 32];
+
+        let header: [u8; 4] = [0x08, 0x00, 0x00, 0x00];
+
+        let mut output_descriptors: DescriptorChain<Output, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        output_descriptors.push(&mut new_state, 32);
+
+        let mut input_descriptors: DescriptorChain<Input, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+
+        input_descriptors.push(&header, 19);
+
+        if let Some(state) = &instance.state {
+            input_descriptors.push(state, 99);
+        }
+
+        input_descriptors.push(data, 35);
+
+        self.execute_cryptomaster_dma(&mut input_descriptors, &mut output_descriptors);
+
+        instance.state = Some(new_state);
+    }
+
+    fn finalize(&mut self, instance: Self::State, last_chunk: &[u8], target: &mut [u8]) {
+        debug_assert!(
+            last_chunk.is_empty(),
+            "Self::SEND_PADDING=true requires user not to send any last chunk"
+        );
+
+        target.copy_from_slice(&instance.state.unwrap());
+    }
+}

--- a/embedded-cal-nrf54l15/src/sha2.rs
+++ b/embedded-cal-nrf54l15/src/sha2.rs
@@ -11,18 +11,6 @@ pub struct HashState {
     state: Option<[u8; 32]>,
 }
 
-pub enum HashResult {
-    Sha256([u8; 32]),
-}
-
-impl AsRef<[u8]> for HashResult {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            HashResult::Sha256(r) => &r[..],
-        }
-    }
-}
-
 impl embedded_cal::plumbing::Plumbing for super::Nrf54l15Cal {}
 
 impl embedded_cal::plumbing::hash::Hash for super::Nrf54l15Cal {}

--- a/embedded-cal-nrf54l15/src/sha3.rs
+++ b/embedded-cal-nrf54l15/src/sha3.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+
+use crate::descriptor::{DescriptorChain, Input, Output};
+
+// BA418 (SHA-3) engine mode codes.
+#[repr(u8)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+enum Variant {
+    Sha3_224 = 0x06,
+    Sha3_256 = 0x07,
+    Sha3_384 = 0x0B,
+    Sha3_512 = 0x0F,
+}
+
+impl Variant {
+    const fn output_len(self) -> usize {
+        match self {
+            Variant::Sha3_224 => 28,
+            Variant::Sha3_256 => 32,
+            Variant::Sha3_384 => 48,
+            Variant::Sha3_512 => 64,
+        }
+    }
+
+    // Keccak absorption rate in bytes: (1600 - 2 * digest_bits) / 8.
+    const fn rate(self) -> usize {
+        match self {
+            Variant::Sha3_224 => 144,
+            Variant::Sha3_256 => 136,
+            Variant::Sha3_384 => 104,
+            Variant::Sha3_512 => 72,
+        }
+    }
+}
+
+// Largest Keccak rate across all SHA-3 variants (SHA3-224 = 144 bytes).
+const MAX_RATE: usize = 144;
+// Full Keccak-f[1600] permutation state (1600 bits).
+const KECCAK_STATE_SIZE: usize = 200;
+
+// BA418 DMA tags.
+// DMATAG_BA418 = 5, DMATAG_CONFIG = 16.
+// DMATAG_LAST (bit 5 = 32) is ORed in automatically by DescriptorChain on the
+// final descriptor of each chain, so data descriptors start at 5.
+const DMATAG_BA418_CONFIG: u32 = 5 | 16; // = 21
+const DMATAG_BA418_DATA: u32 = 5;
+// DMATAG_BA418 | DMATAG_DATATYPE(1) | DMATAG_LAST: re-injects a saved Keccak sponge
+// state. DMATAG_LAST here is a BA418 semantic flag (not the chain terminator): it
+// marks this descriptor as a state-load operation.
+const DMATAG_BA418_INITIAL_STATE: u32 = 5 | (1 << 6) | (1 << 5); // = 101
+
+// SHA3_SAVE_CONTEXT (bit 6 of the BA418 config word): when set, the hardware outputs
+// the 200-byte intermediate Keccak sponge state instead of the final digest.
+const SHA3_SAVE_CONTEXT: u8 = 1 << 6;
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum HashAlgorithm {
+    Sha3_224,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+}
+
+impl HashAlgorithm {
+    fn variant(&self) -> Variant {
+        match self {
+            HashAlgorithm::Sha3_224 => Variant::Sha3_224,
+            HashAlgorithm::Sha3_256 => Variant::Sha3_256,
+            HashAlgorithm::Sha3_384 => Variant::Sha3_384,
+            HashAlgorithm::Sha3_512 => Variant::Sha3_512,
+        }
+    }
+}
+
+impl embedded_cal::HashAlgorithm for HashAlgorithm {
+    fn len(&self) -> usize {
+        self.variant().output_len()
+    }
+
+    fn from_ni_id(id: u8) -> Option<Self> {
+        match id {
+            9 => Some(HashAlgorithm::Sha3_224),
+            10 => Some(HashAlgorithm::Sha3_256),
+            11 => Some(HashAlgorithm::Sha3_384),
+            12 => Some(HashAlgorithm::Sha3_512),
+            _ => None,
+        }
+    }
+
+    fn from_ni_name(name: &str) -> Option<Self> {
+        match name {
+            "sha3-224" => Some(HashAlgorithm::Sha3_224),
+            "sha3-256" => Some(HashAlgorithm::Sha3_256),
+            "sha3-384" => Some(HashAlgorithm::Sha3_384),
+            "sha3-512" => Some(HashAlgorithm::Sha3_512),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HashState {
+    variant: Variant,
+    // Saved Keccak sponge state after the last absorbed full-rate block; None until
+    // the first full block has been processed.
+    state: Option<[u8; KECCAK_STATE_SIZE]>,
+    // Partial block buffer; always contains bytes [0, buf_len).
+    // Bytes [buf_len, MAX_RATE) are kept zeroed.
+    buf: [u8; MAX_RATE],
+    buf_len: usize,
+}
+
+// Sized for the largest possible digest (SHA3-512 = 64 bytes).
+pub struct HashOutput {
+    variant: Variant,
+    buf: [u8; 64],
+}
+
+impl AsRef<[u8]> for HashOutput {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf[..self.variant.output_len()]
+    }
+}
+
+impl super::Nrf54l15Cal {
+    // Sends instance.partial[..rate] to the BA418 with SHA3_SAVE_CONTEXT set,
+    // saves the resulting 200-byte Keccak state, and resets the partial buffer.
+    // Caller must ensure instance.buf_len == rate.
+    fn sha3_absorb_block(&mut self, instance: &mut HashState) {
+        let rate = instance.variant.rate();
+        let header: [u8; 4] = [instance.variant as u8 | SHA3_SAVE_CONTEXT, 0x00, 0x00, 0x00];
+        let mut new_state = [0u8; KECCAK_STATE_SIZE];
+
+        let mut output_descriptors: DescriptorChain<Output, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        output_descriptors.push(&mut new_state, 32);
+
+        let mut input_descriptors: DescriptorChain<Input, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        input_descriptors.push(&header, DMATAG_BA418_CONFIG);
+
+        if let Some(state) = &instance.state {
+            input_descriptors.push(state, DMATAG_BA418_INITIAL_STATE);
+        }
+
+        input_descriptors.push(&instance.buf[..rate], DMATAG_BA418_DATA);
+
+        self.execute_cryptomaster_dma(&mut input_descriptors, &mut output_descriptors);
+
+        instance.state = Some(new_state);
+        instance.buf = [0u8; MAX_RATE];
+        instance.buf_len = 0;
+    }
+}
+
+impl embedded_cal::HashProvider for super::Nrf54l15Cal {
+    type Algorithm = HashAlgorithm;
+    type State = HashState;
+    type Output = HashOutput;
+
+    fn init(&mut self, algorithm: Self::Algorithm) -> Self::State {
+        HashState {
+            variant: algorithm.variant(),
+            state: None,
+            buf: [0u8; MAX_RATE],
+            buf_len: 0,
+        }
+    }
+
+    fn update(&mut self, instance: &mut Self::State, data: &[u8]) {
+        let rate = instance.variant.rate();
+        let mut remaining = data;
+
+        while !remaining.is_empty() {
+            let space = rate - instance.buf_len;
+            let to_copy = remaining.len().min(space);
+            instance.buf[instance.buf_len..instance.buf_len + to_copy]
+                .copy_from_slice(&remaining[..to_copy]);
+            instance.buf_len += to_copy;
+            remaining = &remaining[to_copy..];
+
+            if instance.buf_len == rate {
+                self.sha3_absorb_block(instance);
+            }
+        }
+    }
+
+    fn finalize(&mut self, mut instance: Self::State) -> Self::Output {
+        let rate = instance.variant.rate();
+
+        // FIPS 202 multi-rate padding: place 0x06 after the last message byte, then
+        // OR 0x80 into the last byte of the rate block. When buf_len == rate - 1
+        // both writes land on the same byte, producing 0x86.
+        instance.buf[instance.buf_len] = 0x06;
+        instance.buf[rate - 1] |= 0x80;
+
+        let out_len = instance.variant.output_len();
+        let mut out_buf = [0u8; 64];
+
+        // Config word without SHA3_SAVE_CONTEXT: final operation outputs the digest.
+        let header: [u8; 4] = [instance.variant as u8, 0x00, 0x00, 0x00];
+
+        let mut output_descriptors: DescriptorChain<Output, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        output_descriptors.push(&mut out_buf[..out_len], 32);
+
+        let mut input_descriptors: DescriptorChain<Input, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
+            DescriptorChain::new();
+        input_descriptors.push(&header, DMATAG_BA418_CONFIG);
+
+        if let Some(state) = &instance.state {
+            input_descriptors.push(state, DMATAG_BA418_INITIAL_STATE);
+        }
+
+        input_descriptors.push(&instance.buf[..rate], DMATAG_BA418_DATA);
+
+        self.execute_cryptomaster_dma(&mut input_descriptors, &mut output_descriptors);
+
+        HashOutput {
+            variant: instance.variant,
+            buf: out_buf,
+        }
+    }
+}

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -33,6 +33,38 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_sha3_224(state: &mut super::TestState) {
+        use embedded_cal::{HashAlgorithm, HashProvider};
+        let alg = <embedded_cal_software_demo::Extender<ImplementSha256Short> as HashProvider>::Algorithm::from_ni_name("sha3-224")
+            .expect("sha3-224 must be recognized");
+        testvectors::test_hash_sha3_224(&mut state.cal, alg);
+    }
+
+    #[test]
+    fn test_hash_sha3_256(state: &mut super::TestState) {
+        use embedded_cal::{HashAlgorithm, HashProvider};
+        let alg = <embedded_cal_software_demo::Extender<ImplementSha256Short> as HashProvider>::Algorithm::from_ni_name("sha3-256")
+            .expect("sha3-256 must be recognized");
+        testvectors::test_hash_sha3_256(&mut state.cal, alg);
+    }
+
+    #[test]
+    fn test_hash_sha3_384(state: &mut super::TestState) {
+        use embedded_cal::{HashAlgorithm, HashProvider};
+        let alg = <embedded_cal_software_demo::Extender<ImplementSha256Short> as HashProvider>::Algorithm::from_ni_name("sha3-384")
+            .expect("sha3-384 must be recognized");
+        testvectors::test_hash_sha3_384(&mut state.cal, alg);
+    }
+
+    #[test]
+    fn test_hash_sha3_512(state: &mut super::TestState) {
+        use embedded_cal::{HashAlgorithm, HashProvider};
+        let alg = <embedded_cal_software_demo::Extender<ImplementSha256Short> as HashProvider>::Algorithm::from_ni_name("sha3-512")
+            .expect("sha3-512 must be recognized");
+        testvectors::test_hash_sha3_512(&mut state.cal, alg);
+    }
+
+    #[test]
     fn test_hash_algorithm_sha256(state: &mut super::TestState) {
         embedded_cal::test_hash_algorithm_sha256::<
             <embedded_cal_software_demo::Extender<ImplementSha256Short> as embedded_cal::HashProvider>::Algorithm,

--- a/embedded-cal-software-demo/src/hash.rs
+++ b/embedded-cal-software-demo/src/hash.rs
@@ -196,7 +196,7 @@ impl<EC: ExtenderConfig> embedded_cal::HashAlgorithm for HashAlgorithm<EC> {
     fn from_ni_id(number: u8) -> Option<Self> {
         match number {
             1 => Self::from_cose_number(-16),
-            _ => None,
+            _ => HashAlgorithmOf::<EC::Base>::from_ni_id(number).map(HashAlgorithm::Direct),
         }
     }
 
@@ -204,7 +204,7 @@ impl<EC: ExtenderConfig> embedded_cal::HashAlgorithm for HashAlgorithm<EC> {
     fn from_ni_name(name: &str) -> Option<Self> {
         match name {
             "sha-256" => Self::from_cose_number(-16),
-            _ => None,
+            _ => HashAlgorithmOf::<EC::Base>::from_ni_name(name).map(HashAlgorithm::Direct),
         }
     }
 }

--- a/helpers/ALGORITHMS.cache/enum-algorithm-items
+++ b/helpers/ALGORITHMS.cache/enum-algorithm-items
@@ -18,6 +18,14 @@
     X25519,
 ./embedded-cal-nrf54l15/src/dh.rs
     X448,
+./embedded-cal-nrf54l15/src/sha3.rs
+    Sha3_224,
+./embedded-cal-nrf54l15/src/sha3.rs
+    Sha3_256,
+./embedded-cal-nrf54l15/src/sha3.rs
+    Sha3_384,
+./embedded-cal-nrf54l15/src/sha3.rs
+    Sha3_512,
 ./embedded-cal-rustcrypto/src/aead.rs
     AesCcm16_64_128,
 ./embedded-cal-rustcrypto/src/aead.rs

--- a/helpers/ALGORITHMS.cache/plumbing
+++ b/helpers/ALGORITHMS.cache/plumbing
@@ -1,4 +1,4 @@
-./embedded-cal-nrf54l15/src/lib.rs:impl embedded_cal::plumbing::Plumbing for Nrf54l15Cal {}
+./embedded-cal-nrf54l15/src/sha2.rs:impl embedded_cal::plumbing::Plumbing for super::Nrf54l15Cal {}
 ./embedded-cal-software-demo/src/tests/dummy_sha256.rs:impl embedded_cal::plumbing::Plumbing for DummySha256 {}
 ./embedded-cal-stm32wba55/src/lib.rs:impl embedded_cal::plumbing::Plumbing for Stm32wba55Cal {}
 ./embedded-cal/src/empty.rs:impl plumbing::Plumbing for EmptyCal<true> {}

--- a/helpers/ALGORITHMS.cache/providers
+++ b/helpers/ALGORITHMS.cache/providers
@@ -2,6 +2,7 @@
 ./embedded-cal-libcrux/src/hash.rs:impl<EC: ExtenderConfig> HashProvider for Extender<EC> {
 ./embedded-cal-nrf54l15/src/aead.rs:impl embedded_cal::AeadProvider for super::Nrf54l15Cal {
 ./embedded-cal-nrf54l15/src/dh.rs:impl embedded_cal::DhProvider for super::Nrf54l15Cal {
+./embedded-cal-nrf54l15/src/sha3.rs:impl embedded_cal::HashProvider for super::Nrf54l15Cal {
 ./embedded-cal-rustcrypto/src/aead.rs:impl<Base: Cal> AeadProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-rustcrypto/src/dh.rs:impl<Base: Cal> DhProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-rustcrypto/src/hash.rs:impl<Base: Cal> HashProvider for RustcryptoCalExtender<Base> {

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -6,6 +6,121 @@ use hexlit::hex;
 
 pub mod dh;
 
+/// SHA3-224 test vectors from NIST FIPS 202.
+pub const SHA3_224_HASHES: &[(&[u8], [u8; 28])] = &[
+    (
+        b"",
+        hex!("6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7"),
+    ),
+    (
+        b"abc",
+        hex!("e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf"),
+    ),
+];
+
+/// SHA3-256 test vectors from NIST FIPS 202.
+pub const SHA3_256_HASHES: &[(&[u8], [u8; 32])] = &[
+    (
+        b"",
+        hex!("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"),
+    ),
+    (
+        b"abc",
+        hex!("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"),
+    ),
+];
+
+/// SHA3-384 test vectors from NIST FIPS 202.
+pub const SHA3_384_HASHES: &[(&[u8], [u8; 48])] = &[
+    (
+        b"",
+        hex!(
+            "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004"
+        ),
+    ),
+    (
+        b"abc",
+        hex!(
+            "ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25"
+        ),
+    ),
+];
+
+/// SHA3-512 test vectors from NIST FIPS 202.
+pub const SHA3_512_HASHES: &[(&[u8], [u8; 64])] = &[
+    (
+        b"",
+        hex!(
+            "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"
+        ),
+    ),
+    (
+        b"abc",
+        hex!(
+            "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0"
+        ),
+    ),
+];
+
+fn test_hash_sha3<Cal, const N: usize>(
+    cal: &mut Cal,
+    algorithm: Cal::Algorithm,
+    vectors: &[(&[u8], [u8; N])],
+) where
+    Cal: embedded_cal::HashProvider,
+{
+    for (tv_data, tv_result) in vectors {
+        assert_eq!(
+            cal.hash(algorithm.clone(), tv_data).as_ref(),
+            tv_result,
+            "Hash values mismatch"
+        );
+
+        let mut hash = cal.init(algorithm.clone());
+        let mid = tv_data.len() / 2;
+        let postmid = mid + 1;
+        if tv_data.len() < postmid {
+            continue;
+        }
+        cal.update(&mut hash, &tv_data[..mid]);
+        cal.update(&mut hash, &tv_data[mid..postmid]);
+        cal.update(&mut hash, &tv_data[postmid..]);
+        assert_eq!(
+            cal.finalize(hash).as_ref(),
+            tv_result,
+            "Hash values mismatch when input is fed in chunks"
+        );
+    }
+}
+
+pub fn test_hash_sha3_224<Cal: embedded_cal::HashProvider>(
+    cal: &mut Cal,
+    algorithm: Cal::Algorithm,
+) {
+    test_hash_sha3(cal, algorithm, SHA3_224_HASHES);
+}
+
+pub fn test_hash_sha3_256<Cal: embedded_cal::HashProvider>(
+    cal: &mut Cal,
+    algorithm: Cal::Algorithm,
+) {
+    test_hash_sha3(cal, algorithm, SHA3_256_HASHES);
+}
+
+pub fn test_hash_sha3_384<Cal: embedded_cal::HashProvider>(
+    cal: &mut Cal,
+    algorithm: Cal::Algorithm,
+) {
+    test_hash_sha3(cal, algorithm, SHA3_384_HASHES);
+}
+
+pub fn test_hash_sha3_512<Cal: embedded_cal::HashProvider>(
+    cal: &mut Cal,
+    algorithm: Cal::Algorithm,
+) {
+    test_hash_sha3(cal, algorithm, SHA3_512_HASHES);
+}
+
 pub const SHA256HASHES: &[(&[u8], [u8; 32])] = &[
     (
         b"",


### PR DESCRIPTION
Looking deeper on the CRACEN documentation, we have access to SHA3 (just on another module `BA418`)

So this PR implements directly the SHA3 (224, 256, 384, 512) for nRF54 (there is no SHA3 in the STM32WBA55 :/)

That means that things like padding is directly baked on the `finalize`, etc. I didn't create an plumbing for it, since I don't know what to make generic for.