### PR TITLE
[experiment] Aad on nrf54 

### DIFF
--- a/embedded-cal-nrf54l15/src/aead.rs
+++ b/embedded-cal-nrf54l15/src/aead.rs
@@ -33,6 +33,46 @@ const AES_CMD_CCM_DECRYPT: u32 = AES_CCM_MODE | 1; // 0x2001
 
 use crate::descriptor::{DescriptorChain, Input, Output, dmatag_ign};
 
+/// Pushes the CCM header (the `DMATAG_AES_AAD` descriptors) onto `input_chain`: B0, then — when
+/// AAD is present — the 2-byte big-endian length prefix, the AAD chunks streamed straight from the
+/// caller, and the trailing CCM zero-pad.
+///
+/// Every descriptor up to the last AAD-type one is RAW (no realign) so the fetcher carries sub-word
+/// remainders straight into the next descriptor, keeping the CBC-MAC byte stream contiguous. The
+/// final AAD-type descriptor must use `push` (realign) so the engine flushes the block before the
+/// message data: that is the zero-pad when the header is not block-aligned, otherwise the last AAD
+/// chunk itself.
+///
+/// `header_pad` is the zero-padding slice already trimmed to its length (`header_ign` bytes, 0..16);
+/// its length doubles as the ignore count for the final descriptor.
+fn push_ccm_header<'mem, const N: usize>(
+    input_chain: &mut DescriptorChain<'mem, Input, N>,
+    b0: &'mem [u8],
+    aad_len: usize,
+    aad_len_prefix: &'mem [u8],
+    aad: &'mem impl embedded_cal::AadGenerator,
+    header_pad: &'mem [u8],
+) {
+    input_chain.push(b0, DMATAG_AES_AAD);
+    if aad_len == 0 {
+        return;
+    }
+    let header_ign = header_pad.len();
+    input_chain.push_raw(aad_len_prefix, DMATAG_AES_AAD);
+    let mut chunks = aad.items().filter(|c| !c.is_empty()).peekable();
+    while let Some(chunk) = chunks.next() {
+        if chunks.peek().is_none() && header_ign == 0 {
+            // Last AAD-type descriptor: it MUST realign, so use `push` (not `push_raw`).
+            input_chain.push(chunk, DMATAG_AES_AAD);
+        } else {
+            input_chain.push_raw(chunk, DMATAG_AES_AAD);
+        }
+    }
+    if header_ign > 0 {
+        input_chain.push(header_pad, DMATAG_AES_AAD | dmatag_ign(header_ign));
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AeadAlgorithm {
     AesCcm16_64_128,
@@ -100,26 +140,14 @@ impl super::Nrf54l15Cal {
         const TAG_LEN: usize = 8;
         let cmd = AES_CMD_CCM_ENCRYPT.to_le_bytes();
 
-        // Header = B0 (16 B) + [aad_len_be (2 B) + aad] when AAD present,
-        // zero-padded to the next 16-byte multiple.
-        // Max size: 16 + 2 + 255 = 273 → pads to 288.
-        // Write AAD chunks directly at offset 18, then fill B0 and length prefix.
-        let mut header_buf = [0u8; 288];
         let mut aad_len = 0usize;
         for chunk in aad.items() {
-            header_buf[18 + aad_len..18 + aad_len + chunk.len()].copy_from_slice(chunk);
             aad_len += chunk.len();
         }
         let b0 = embedded_cal::build_b0(nonce, message.len(), aad_len, TAG_LEN);
-        let header_data_len = if aad_len == 0 {
-            header_buf[..16].copy_from_slice(&b0);
-            16
-        } else {
-            header_buf[..16].copy_from_slice(&b0);
-            header_buf[16] = (aad_len >> 8) as u8;
-            header_buf[17] = (aad_len & 0xFF) as u8;
-            18 + aad_len
-        };
+        let aad_len_prefix = [(aad_len >> 8) as u8, (aad_len & 0xFF) as u8];
+        let header_pad = [0u8; 16];
+        let header_data_len = if aad_len == 0 { 16 } else { 18 + aad_len };
         let header_padded_len = (header_data_len + 15) & !15;
         let header_ign = header_padded_len - header_data_len;
 
@@ -134,7 +162,10 @@ impl super::Nrf54l15Cal {
         // The BA411E emits one output byte per header input byte (intermediate
         // CBC-MAC state). Absorb those into a scratch buffer so that ct_buf and
         // tag_out_buf receive the correct ciphertext and tag.
-        let mut header_out_buf = [0u8; 288];
+        let mut b0_out_buf = [0u8; 16];
+        // One output byte per header input byte after B0: aad_len (2 B) + aad + zero-pad =
+        // header_padded_len - 16 B (max 288 - 16 = 272). Output count matches input exactly.
+        let mut header_aad_out_buf = [0u8; 272];
 
         let mut input_chain: DescriptorChain<Input, { super::MAX_DESCRIPTOR_CHAIN_LEN }> =
             DescriptorChain::new();
@@ -143,9 +174,13 @@ impl super::Nrf54l15Cal {
 
         input_chain.push(&cmd, DMATAG_AES_CFG);
         input_chain.push(key, DMATAG_AES_KEY);
-        input_chain.push(
-            &header_buf[..header_padded_len],
-            DMATAG_AES_AAD | dmatag_ign(header_ign),
+        push_ccm_header(
+            &mut input_chain,
+            &b0,
+            aad_len,
+            &aad_len_prefix,
+            &aad,
+            &header_pad[..header_ign],
         );
         if !message.is_empty() {
             input_chain.push(
@@ -153,7 +188,10 @@ impl super::Nrf54l15Cal {
                 DMATAG_AES_DATA | dmatag_ign(msg_ign),
             );
         }
-        output_chain.push(&mut header_out_buf[..header_padded_len], 0);
+        output_chain.push(&mut b0_out_buf, 0);
+        if aad_len > 0 {
+            output_chain.push(&mut header_aad_out_buf[..header_padded_len - 16], 0);
+        }
         if !message.is_empty() {
             output_chain.push(&mut ct_buf[..msg_padded_len], 0);
         }
@@ -185,22 +223,16 @@ impl super::Nrf54l15Cal {
         const TAG_LEN: usize = 8;
         let cmd = AES_CMD_CCM_DECRYPT.to_le_bytes();
 
-        let mut header_buf = [0u8; 288];
+        // See `ccm_encrypt` for the header layout; the AAD is streamed straight from the caller's
+        // chunks, with only B0, the length prefix, and the zero-pad in local buffers.
         let mut aad_len = 0usize;
         for chunk in aad.items() {
-            header_buf[18 + aad_len..18 + aad_len + chunk.len()].copy_from_slice(chunk);
             aad_len += chunk.len();
         }
         let b0 = embedded_cal::build_b0(nonce, ciphertext.len(), aad_len, TAG_LEN);
-        let header_data_len = if aad_len == 0 {
-            header_buf[..16].copy_from_slice(&b0);
-            16
-        } else {
-            header_buf[..16].copy_from_slice(&b0);
-            header_buf[16] = (aad_len >> 8) as u8;
-            header_buf[17] = (aad_len & 0xFF) as u8;
-            18 + aad_len
-        };
+        let aad_len_prefix = [(aad_len >> 8) as u8, (aad_len & 0xFF) as u8];
+        let header_pad = [0u8; 16];
+        let header_data_len = if aad_len == 0 { 16 } else { 18 + aad_len };
         let header_padded_len = (header_data_len + 15) & !15;
         let header_ign = header_padded_len - header_data_len;
 
@@ -225,9 +257,13 @@ impl super::Nrf54l15Cal {
 
         input_chain.push(&cmd, DMATAG_AES_CFG);
         input_chain.push(key, DMATAG_AES_KEY);
-        input_chain.push(
-            &header_buf[..header_padded_len],
-            DMATAG_AES_AAD | dmatag_ign(header_ign),
+        push_ccm_header(
+            &mut input_chain,
+            &b0,
+            aad_len,
+            &aad_len_prefix,
+            &aad,
+            &header_pad[..header_ign],
         );
         if !ciphertext.is_empty() {
             input_chain.push(

--- a/embedded-cal-nrf54l15/src/descriptor.rs
+++ b/embedded-cal-nrf54l15/src/descriptor.rs
@@ -8,6 +8,7 @@
     reason = "nRF54L15 uses 1 as last-descriptor sentinel"
 )]
 const LAST_DESC_PTR: *mut Descriptor = 1 as *mut Descriptor;
+const DMA_REALIGN: u32 = 1 << 29;
 /// Single EasyDMA scatter-gather job entry.
 ///
 /// This structure maps directly to one hardware “job entry” consumed by the
@@ -75,6 +76,9 @@ pub(crate) struct Output;
 pub(crate) struct DescriptorChain<'mem, Direction, const N: usize> {
     descs: [Descriptor; N],
     count: usize,
+    /// Bytes accumulated since the last realign (`DMA_REALIGN`) descriptor — i.e. the running total
+    /// fed by `push_raw`. A realign `push` must bring this to a word boundary before resetting it.
+    pending: usize,
     _dir: core::marker::PhantomData<*mut &'mem Direction>,
 }
 
@@ -87,6 +91,7 @@ impl<'mem, Direction, const N: usize> DescriptorChain<'mem, Direction, N> {
         Self {
             descs: [Descriptor::empty(); N],
             count: 0,
+            pending: 0,
             _dir: core::marker::PhantomData,
         }
     }
@@ -164,9 +169,47 @@ impl<'mem, const N: usize> DescriptorChain<'mem, Input, N> {
     /// - `data` must be DMA-accessible memory.
     /// - `data.len()` must be a multiple of 4.
     pub(crate) fn push(&mut self, data: &'mem [u8], dmatag: u32) {
+        // Realigning descriptor: the cumulative byte count fed since the last realign point (any
+        // preceding `push_raw` bytes plus this descriptor) must land on a word boundary, otherwise
+        // the fetcher flushes a partial word and corrupts the stream.
+        self.pending += data.len();
+        debug_assert!(
+            self.pending.is_multiple_of(4),
+            "Cumulative bytes at a realign point must be a multiple of the word size"
+        );
+        self.pending = 0;
         self.push_descriptor(Descriptor::new(
             data.as_ptr() as *mut u8,
             sz(data.len()),
+            dmatag,
+        ));
+    }
+
+    /// Appends an input (read) buffer *without* the `DMA_REALIGN` flag.
+    ///
+    /// Omitting `DMA_REALIGN` makes the fetcher keep its partial-word accumulator across this
+    /// descriptor's boundary, so the descriptor's trailing 1-3 bytes are byte-concatenated with
+    /// the *next* descriptor's data instead of being padded out to a 32-bit word boundary. This
+    /// mirrors `ADD_RAW_INDESC` in the Nordic SDK (`cmdma.h`), which `sx_hash_feed` uses to stream
+    /// arbitrary-length chunks. It is the mechanism for feeding a sub-word field (e.g. the 2-byte
+    /// CCM AAD length prefix) in its own descriptor while keeping the byte stream contiguous.
+    ///
+    /// Unlike [`push`](Self::push), `data.len()` need not be a multiple of 4. Whatever descriptor
+    /// follows must bring the cumulative byte count back to a word boundary by the next
+    /// `DMA_REALIGN` point.
+    ///
+    /// Must **not** be used for the last descriptor of a data type (or of the whole chain): without
+    /// `DMA_REALIGN` the fetcher never flushes its trailing partial word — it always defers the
+    /// sub-word remainder to the next descriptor. A terminal descriptor has no next one, so its
+    /// pending bytes would be left unflushed. Use [`push`](Self::push) there instead; it realigns
+    /// and flushes (and is also the only variant that can mark trailing padding via `dmatag_ign`).
+    pub(crate) fn push_raw(&mut self, data: &'mem [u8], dmatag: u32) {
+        // RAW descriptor: no realign, so its (possibly sub-word) bytes accumulate into `pending` for
+        // a later realigning `push` to bring back to a word boundary.
+        self.pending += data.len();
+        self.push_descriptor(Descriptor::new(
+            data.as_ptr() as *mut u8,
+            data.len() as u32,
             dmatag,
         ));
     }
@@ -180,7 +223,16 @@ impl<'mem, const N: usize> DescriptorChain<'mem, Output, N> {
     /// # Safety / Correctness requirements
     ///
     /// - `data` must be DMA-accessible memory.
+    /// - `data.len()` must be a multiple of 4.
     pub(crate) fn push(&mut self, data: &'mem mut [u8], dmatag: u32) {
+        // Realigning descriptor: the cumulative byte count fed since the last realign point must land
+        // on a word boundary before the fetcher flushes.
+        self.pending += data.len();
+        debug_assert!(
+            self.pending.is_multiple_of(4),
+            "cumulative bytes at a realign point must be a multiple of the word size"
+        );
+        self.pending = 0;
         self.push_descriptor(Descriptor::new(data.as_mut_ptr(), sz(data.len()), dmatag));
     }
 }
@@ -191,13 +243,13 @@ pub(crate) const fn dmatag_ign(n: usize) -> u32 {
     (n as u32) << 8
 }
 
-/// Asserts that size is a multiple of 4, and ORs in the DMA_REALIGN constant.
+/// ORs in the `DMA_REALIGN` constant.
+///
+/// Note: `n` need NOT be a multiple of the word size. A realign descriptor may complete a partial
+/// word left by preceding RAW (`push_raw`) descriptors; what matters is that the *cumulative* byte
+/// count is word-aligned at the realign point, not that this single descriptor's length is. The
+/// engine handles the sub-word completion via `DMA_REALIGN`.
 #[inline]
 const fn sz(n: usize) -> u32 {
-    const DMA_REALIGN: usize = 0x2000_0000;
-    debug_assert!(
-        n.is_multiple_of(4),
-        "Sizes passed through this function need to be in multiples of the word size"
-    );
-    (n | DMA_REALIGN) as u32
+    n as u32 | DMA_REALIGN
 }

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -14,7 +14,8 @@ use nrf_pac::{cracen, cracencore};
 
 // CCM encrypt needs 4 input descriptors (config, key, header+aad, plaintext) and
 // 3 output descriptors (header scratch, ciphertext, tag). Decrypt needs 5 input (+ expected tag).
-const MAX_DESCRIPTOR_CHAIN_LEN: usize = 6;
+// 32 is an arbitrary value, picked large enough to comfortably hold the fixed descriptors plus a reasonably chunked AAD
+const MAX_DESCRIPTOR_CHAIN_LEN: usize = 32;
 
 pub struct Nrf54l15Cal {
     // FIXME: No need to enable and take ownership of everything

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -361,6 +361,20 @@ pub fn test_hash_algorithm_sha256<Cal: embedded_cal::HashProvider>(cal: &mut Cal
     }
 }
 
+// An [`embedded_cal::AadGenerator`] that yields its data split into fixed-size pieces, so the
+// scatter-gather AAD path (multiple descriptors / chunks) is tested.
+#[derive(Clone, Copy)]
+struct ChunkedAad<'a> {
+    data: &'a [u8],
+    chunk: usize,
+}
+
+impl embedded_cal::AadGenerator for ChunkedAad<'_> {
+    fn items(&self) -> impl Iterator<Item = &[u8]> {
+        self.data.chunks(self.chunk.max(1))
+    }
+}
+
 pub struct AeadCase {
     alg_cose: i16,
     key: &'static [u8],
@@ -385,8 +399,6 @@ impl AeadCase {
         let buf = &mut buf[..self.plaintext.len()];
         buf.copy_from_slice(self.plaintext);
 
-        // FIXME: try again with chunked AAD
-
         let produced_tag = cal.encrypt_in_place(&key, self.nonce, buf, self.aad);
 
         assert_eq!(
@@ -406,6 +418,32 @@ impl AeadCase {
         assert_eq!(
             buf, self.plaintext,
             "decryption mismatch: expected {:02x?}, got {:02x?}",
+            self.plaintext, buf
+        );
+
+        // test with chunked `AadGenerator`
+        let chunked_aad = ChunkedAad {
+            data: self.aad,
+            chunk: 3,
+        };
+        let chunked_tag = cal.encrypt_in_place(&key, self.nonce, buf, chunked_aad);
+        assert_eq!(
+            buf, self.ciphertext,
+            "chunked-AAD ciphertext mismatch: expected {:02x?}, got {:02x?}",
+            self.ciphertext, buf
+        );
+        assert_eq!(
+            chunked_tag.as_ref(),
+            self.tag,
+            "chunked-AAD tag mismatch: expected {:02x?}, got {:02x?}",
+            self.tag,
+            chunked_tag.as_ref()
+        );
+        cal.decrypt_in_place(&key, self.nonce, buf, self.tag, chunked_aad)
+            .unwrap();
+        assert_eq!(
+            buf, self.plaintext,
+            "chunked-AAD decryption mismatch: expected {:02x?}, got {:02x?}",
             self.plaintext, buf
         );
     }

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -388,6 +388,7 @@ impl AeadCase {
         // FIXME: try again with chunked AAD
 
         let produced_tag = cal.encrypt_in_place(&key, self.nonce, buf, self.aad);
+
         assert_eq!(
             produced_tag.as_ref(),
             self.tag,
@@ -400,7 +401,6 @@ impl AeadCase {
             "ciphertext mismatch: expected {:02x?}, got {:02x?}",
             self.ciphertext, buf
         );
-
         cal.decrypt_in_place(&key, self.nonce, buf, self.tag, self.aad)
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
This PR remove the copy the AAD on a buffer.


Before

CCM encrypt/decrypt built the whole authenticated header in one [u8; 288] stack buffer: it copied b0, the 2-byte AAD length prefix, and then every chunk of the AadGenerator into that buffer, and finally handed the buffer as a single  descriptor to the nRF54 scatter-gather engine.

After

We no longer copy the AAD. The header is fed as a sequence of descriptors that point directly at the caller's memory:

1. push(b0) — realign
2. push_raw(aad_len_prefix) — the 2-byte length, RAW (sub-word)
3. push_raw(chunk) for each AadGenerator chunk, streamed straight from the caller
4. a final realigning descriptor: the zero-pad (with DMATAG_IGN) when the header isn't block-aligned, otherwise the last AAD chunk itself