### PR TITLE
README: Declare that we don't have an MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ or implementations of [SUIT](https://datatracker.ietf.org/doc/draft-ietf-suit-ma
 The project is currently being launched,
 and expected to become usable before the end of 2025.
 
+## MSRV
+
+These crates currently have no MSRV; they target latest stable Rust at the time of writing.
+
+Examples can use unstable features if it needed.
+
 ## Publications
 
 `embedded-cal` was introduced in:


### PR DESCRIPTION
Picking up https://github.com/lake-rs/embedded-cal/pull/87#discussion_r3527909105 from @jschneider-bensch:

> I don't know what the current MSRV is of embedded-cal, or of its intended primary users, and I don't know if we have to think too much about it. Just wondering if there are some thoughts around it, when I saw the impl here again.

Embedded Rust tends to track the stable releases rather quickly. The only exception is when it comes to Ferrocene (qualified compiler) – that usually has releases often enough that by the time you write something on latest stable, until people want to run it in a qualified environment, there's usually a Ferrocene release with it. The only critical point is when you want to become part of their tooling (as that supports also longer-ago versions), but that's not a goal here.