### PR TITLE
RFC: Add a trait for Signatures (ECDSA/EdDSA)

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -53,3 +53,9 @@ Limitation in AAD streaming or message size are subject to ongoing work.
 | Algorithm | Implementation | Notes |
 |-----------|----------------|-------|
 | HKDF on HMAC w/ SHA-256 | blanket | to be moved into implementations |
+
+# Sign
+
+| Algorithm | Implementation | Notes |
+|-----------|----------------|-------|
+| ECDSA on curve P-256 | rustcrypto | public-key import via compact (x-only) representation is unverified |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,8 +352,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
 ]
 
 [[package]]
@@ -893,8 +907,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1006,6 +1022,16 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1123,6 +1149,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/embedded-cal-libcrux/src/lib.rs
+++ b/embedded-cal-libcrux/src/lib.rs
@@ -31,6 +31,7 @@ impl<EC: ExtenderConfig> Cal for Extender<EC> {
     type HashProvider = Self;
     // FIXME: This should just be provided as well.
     type HmacProvider = HmacProviderOf<EC::Base>;
+    type SignProvider = SignProviderOf<EC::Base>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self.0.dh()
@@ -43,5 +44,8 @@ impl<EC: ExtenderConfig> Cal for Extender<EC> {
     }
     fn hmac(&mut self) -> &mut Self::HmacProvider {
         self.0.hmac()
+    }
+    fn sign(&mut self) -> &mut Self::SignProvider {
+        self.0.sign()
     }
 }

--- a/embedded-cal-nrf54l15/src/lib.rs
+++ b/embedded-cal-nrf54l15/src/lib.rs
@@ -31,6 +31,7 @@ impl embedded_cal::Cal for Nrf54l15Cal {
     type AeadProvider = Self;
     type HashProvider = EmptyCal<false>;
     type HmacProvider = EmptyCal<false>;
+    type SignProvider = EmptyCal<false>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self
@@ -45,6 +46,10 @@ impl embedded_cal::Cal for Nrf54l15Cal {
     }
 
     fn hmac(&mut self) -> &mut Self::HmacProvider {
+        &mut self.empty
+    }
+
+    fn sign(&mut self) -> &mut Self::SignProvider {
         &mut self.empty
     }
 }

--- a/embedded-cal-rustcrypto/Cargo.toml
+++ b/embedded-cal-rustcrypto/Cargo.toml
@@ -17,7 +17,7 @@ ccm = { version = "0.5.0", default-features = false }
 digest = "0.10.7"
 embedded-cal.path = "../embedded-cal"
 heapless = { version = "0.9.3", features = ["zeroize"] }
-p256 = { version = "0.13.2", default-features = false, features = ["ecdh"] }
+p256 = { version = "0.13.2", default-features = false, features = ["ecdh", "ecdsa"] }
 sha2 = { version = "0.10.9", default-features = false }
 testvectors.path = "../testvectors"
 zeroize = { version = "1.8.2", default-features = false }

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -161,6 +161,15 @@ mod tests {
     }
 
     #[test]
+    fn test_ecdsa_p256() {
+        let mut cal = RustcryptoCal::new();
+
+        for vec in testvectors::sign::ECDSA_P256 {
+            vec.test_with(&mut cal);
+        }
+    }
+
+    #[test]
     fn test_aead_aesccm_16_64_256() {
         let mut cal = RustcryptoCal::new();
 

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -5,6 +5,7 @@ mod aead;
 mod dh;
 mod hash;
 mod rng;
+mod sign;
 
 use digest::Digest;
 use embedded_cal::{accessor::*, empty};
@@ -63,7 +64,7 @@ impl<Base: embedded_cal::Cal> embedded_cal::Cal for RustcryptoCalExtender<Base> 
     type AeadProvider = Self;
     type HashProvider = Self;
     type HmacProvider = HmacProviderOf<Base>;
-    type SignProvider = SignProviderOf<Base>;
+    type SignProvider = Self;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self
@@ -78,7 +79,7 @@ impl<Base: embedded_cal::Cal> embedded_cal::Cal for RustcryptoCalExtender<Base> 
         self.base.hmac()
     }
     fn sign(&mut self) -> &mut Self::SignProvider {
-        self.base.sign()
+        self
     }
 }
 

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -63,6 +63,7 @@ impl<Base: embedded_cal::Cal> embedded_cal::Cal for RustcryptoCalExtender<Base> 
     type AeadProvider = Self;
     type HashProvider = Self;
     type HmacProvider = HmacProviderOf<Base>;
+    type SignProvider = SignProviderOf<Base>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self
@@ -75,6 +76,9 @@ impl<Base: embedded_cal::Cal> embedded_cal::Cal for RustcryptoCalExtender<Base> 
     }
     fn hmac(&mut self) -> &mut Self::HmacProvider {
         self.base.hmac()
+    }
+    fn sign(&mut self) -> &mut Self::SignProvider {
+        self.base.sign()
     }
 }
 

--- a/embedded-cal-rustcrypto/src/sign.rs
+++ b/embedded-cal-rustcrypto/src/sign.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+use embedded_cal::{Cal, ImportError, SignProvider, SignatureInvalid, util::Either};
+use p256::elliptic_curve::point::DecompressPoint;
+
+use super::*;
+
+impl<Base: Cal> SignProvider for RustcryptoCalExtender<Base> {
+    type Algorithm = SignAlgorithm<SignAlgorithmOf<Base>>;
+    type Signature = Signature<SignSignatureOf<Base>>;
+    type SecretKey = SignSecretKey<SignSecretKeyOf<Base>>;
+    type PublicKey = SignPublicKey<SignPublicKeyOf<Base>>;
+    type VisibleSecretKey = SignVisibleSecretKey<SignVisibleSecretKeyOf<Base>>;
+
+    fn generate_visible(&mut self, alg: Self::Algorithm) -> Self::VisibleSecretKey {
+        match alg {
+            SignAlgorithm::EcdsaP256 => {
+                SignVisibleSecretKey::EcdsaP256(p256::ecdsa::SigningKey::random(&mut OldRng(self)))
+            }
+            SignAlgorithm::Direct(d) => {
+                SignVisibleSecretKey::Direct(self.base.sign().generate_visible(d))
+            }
+        }
+    }
+
+    fn export_secretkey_bytes<'s>(
+        &mut self,
+        secretkey: &'s Self::VisibleSecretKey,
+    ) -> impl AsRef<[u8]> + use<'s, Base> {
+        const MAX_SECRET_BYTES_LEN: usize = 32;
+        match secretkey {
+            SignVisibleSecretKey::EcdsaP256(signing_key) => {
+                Either::Own(heapless::vec::Vec::<u8, MAX_SECRET_BYTES_LEN>::from(<[u8;
+                    32]>::from(
+                    signing_key.to_bytes(),
+                )))
+            }
+            SignVisibleSecretKey::Direct(d) => {
+                Either::Direct(self.base.sign().export_secretkey_bytes(d))
+            }
+        }
+    }
+
+    fn import_secretkey_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        secret: &[u8],
+    ) -> Result<Self::VisibleSecretKey, embedded_cal::ImportError> {
+        Ok(match alg {
+            SignAlgorithm::EcdsaP256 => SignVisibleSecretKey::EcdsaP256(
+                p256::ecdsa::SigningKey::from_bytes(secret.into()).map_err(|_| ImportError)?,
+            ),
+            SignAlgorithm::Direct(d) => {
+                SignVisibleSecretKey::Direct(self.base.sign().import_secretkey_bytes(d, secret)?)
+            }
+        })
+    }
+
+    fn export_publickey_bytes<'p>(
+        &mut self,
+        public: &'p Self::PublicKey,
+    ) -> impl AsRef<[u8]> + use<'p, Base> {
+        match public {
+            SignPublicKey::EcdsaP256(verifying_key) => Either::Own(
+                *verifying_key
+                    .to_encoded_point(false)
+                    .x()
+                    .expect("VerifyingKey can never be the identity point")
+                    .as_array::<32>()
+                    .expect("P-256 field elements are always 32 bytes"),
+            ),
+            SignPublicKey::Direct(d) => Either::Direct(self.base.sign().export_publickey_bytes(d)),
+        }
+    }
+
+    fn import_publickey_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        data: &[u8],
+    ) -> Result<Self::PublicKey, embedded_cal::ImportError> {
+        match alg {
+            SignAlgorithm::EcdsaP256 => Ok(SignPublicKey::EcdsaP256(
+                p256::ecdsa::VerifyingKey::from_affine(
+                    p256::AffinePoint::decompress(
+                        &<[u8; 32]>::try_from(data).map_err(|_| ImportError)?.into(),
+                        // Using the trick from
+                        // https://datatracker.ietf.org/doc/html/rfc9528#name-compact-representation,
+                        // picking an arbitrary version for the compact import
+                        0.into(),
+                    )
+                    .into_option()
+                    .ok_or(ImportError)?,
+                )
+                .map_err(|_| ImportError)?,
+            )),
+            SignAlgorithm::Direct(d) => self
+                .base
+                .sign()
+                .import_publickey_bytes(d, data)
+                .map(SignPublicKey::Direct),
+        }
+    }
+
+    fn public_key(&mut self, private: &Self::SecretKey) -> Self::PublicKey {
+        match private {
+            SignSecretKey::EcdsaP256(signing_key) => {
+                SignPublicKey::EcdsaP256(*signing_key.verifying_key())
+            }
+            SignSecretKey::Direct(d) => SignPublicKey::Direct(self.base.sign().public_key(d)),
+        }
+    }
+
+    fn export_signature_bytes<'s>(
+        &mut self,
+        signature: &'s Self::Signature,
+    ) -> impl AsRef<[u8]> + use<'s, Base> {
+        match signature {
+            Signature::EcdsaP256(sig) => Either::Own(sig.to_bytes()),
+            Signature::Direct(d) => Either::Direct(self.base.sign().export_signature_bytes(d)),
+        }
+    }
+
+    fn import_signature_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        data: &[u8],
+    ) -> Result<Self::Signature, embedded_cal::ImportError> {
+        match alg {
+            SignAlgorithm::EcdsaP256 => Ok(Signature::EcdsaP256(
+                #[allow(
+                    clippy::unnecessary_fallible_conversions,
+                    reason = "GenericArray has panicking From for slices"
+                )]
+                p256::ecdsa::Signature::from_bytes(data.try_into().map_err(|_| ImportError)?)
+                    .map_err(|_| ImportError)?,
+            )),
+            SignAlgorithm::Direct(d) => self
+                .base
+                .sign()
+                .import_signature_bytes(d, data)
+                .map(Signature::Direct),
+        }
+    }
+
+    fn sign(&mut self, private: &Self::SecretKey, message: &[u8]) -> Self::Signature {
+        use p256::ecdsa::signature::Signer;
+        match private {
+            SignSecretKey::EcdsaP256(secret_key) => Signature::EcdsaP256(secret_key.sign(message)),
+            SignSecretKey::Direct(secret_key) => {
+                Signature::Direct(self.base.sign().sign(secret_key, message))
+            }
+        }
+    }
+
+    fn verify(
+        &mut self,
+        public: &Self::PublicKey,
+        message: &[u8],
+        signature: &Self::Signature,
+    ) -> Result<(), embedded_cal::SignatureInvalid> {
+        use p256::ecdsa::signature::Verifier;
+        match (public, signature) {
+            (SignPublicKey::EcdsaP256(public_key), Signature::EcdsaP256(sig)) => public_key
+                .verify(message, sig)
+                .map_err(|_| SignatureInvalid),
+            (SignPublicKey::Direct(public_key), Signature::Direct(sig)) => {
+                self.base.sign().verify(public_key, message, sig)
+            }
+            _ => Err(SignatureInvalid),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum SignAlgorithm<BA> {
+    EcdsaP256,
+    Direct(BA),
+}
+
+impl<BA: embedded_cal::SignAlgorithm> embedded_cal::SignAlgorithm for SignAlgorithm<BA> {
+    fn signature_length(&self) -> usize {
+        match self {
+            SignAlgorithm::EcdsaP256 => 64,
+            SignAlgorithm::Direct(base) => base.signature_length(),
+        }
+    }
+
+    fn from_cose_number(alg: impl Into<i128>) -> Option<Self> {
+        let alg: i128 = alg.into();
+        if let Some(d) = BA::from_cose_number(alg) {
+            return Some(SignAlgorithm::Direct(d));
+        }
+        Some(match alg {
+            -7 => SignAlgorithm::EcdsaP256,
+            _ => return None,
+        })
+    }
+}
+
+pub enum Signature<BSIG> {
+    EcdsaP256(p256::ecdsa::Signature),
+    Direct(BSIG),
+}
+
+pub enum SignSecretKey<BSK> {
+    EcdsaP256(p256::ecdsa::SigningKey),
+    Direct(BSK),
+}
+
+pub enum SignPublicKey<BPK> {
+    EcdsaP256(p256::ecdsa::VerifyingKey),
+    Direct(BPK),
+}
+
+pub enum SignVisibleSecretKey<BVSK> {
+    EcdsaP256(p256::ecdsa::SigningKey),
+    Direct(BVSK),
+}
+
+impl<BVSK, BSK> From<SignVisibleSecretKey<BVSK>> for SignSecretKey<BSK>
+where
+    BVSK: Into<BSK>,
+{
+    fn from(value: SignVisibleSecretKey<BVSK>) -> Self {
+        match value {
+            SignVisibleSecretKey::EcdsaP256(signing_key) => SignSecretKey::EcdsaP256(signing_key),
+            SignVisibleSecretKey::Direct(d) => SignSecretKey::Direct(d.into()),
+        }
+    }
+}
+
+struct OldRng<'c, C: embedded_cal::Cal>(&'c mut C);
+
+impl<'c, C: embedded_cal::Cal + rand_core::CryptoRng> rand_core_06::CryptoRng for OldRng<'c, C> {}
+impl<'c, C: embedded_cal::Cal + rand_core::CryptoRng> rand_core_06::RngCore for OldRng<'c, C> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
+        self.0.fill_bytes(dest);
+        Ok(())
+    }
+}

--- a/embedded-cal-software-demo/src/lib.rs
+++ b/embedded-cal-software-demo/src/lib.rs
@@ -33,6 +33,7 @@ impl<EC: ExtenderConfig> embedded_cal::Cal for Extender<EC> {
     type AeadProvider = AeadProviderOf<EC::Base>;
     type HashProvider = Self;
     type HmacProvider = Self;
+    type SignProvider = SignProviderOf<EC::Base>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self.0.dh()
@@ -48,6 +49,10 @@ impl<EC: ExtenderConfig> embedded_cal::Cal for Extender<EC> {
 
     fn hmac(&mut self) -> &mut Self::HmacProvider {
         self
+    }
+
+    fn sign(&mut self) -> &mut Self::SignProvider {
+        self.0.sign()
     }
 }
 

--- a/embedded-cal-software-demo/src/tests/dummy_sha256.rs
+++ b/embedded-cal-software-demo/src/tests/dummy_sha256.rs
@@ -37,6 +37,7 @@ impl embedded_cal::Cal for DummySha256 {
     type AeadProvider = EmptyCal<false>;
     type HashProvider = EmptyCal<false>;
     type HmacProvider = EmptyCal<false>;
+    type SignProvider = EmptyCal<false>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         &mut self.0
@@ -51,6 +52,10 @@ impl embedded_cal::Cal for DummySha256 {
     }
 
     fn hmac(&mut self) -> &mut Self::HmacProvider {
+        &mut self.0
+    }
+
+    fn sign(&mut self) -> &mut Self::SignProvider {
         &mut self.0
     }
 }

--- a/embedded-cal-stm32wba55/src/lib.rs
+++ b/embedded-cal-stm32wba55/src/lib.rs
@@ -38,6 +38,7 @@ impl embedded_cal::Cal for Stm32wba55Cal {
     type AeadProvider = Self;
     type HashProvider = EmptyCal<false>;
     type HmacProvider = Self;
+    type SignProvider = EmptyCal<false>;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self
@@ -51,6 +52,10 @@ impl embedded_cal::Cal for Stm32wba55Cal {
     }
     fn hmac(&mut self) -> &mut Self::HmacProvider {
         self
+    }
+
+    fn sign(&mut self) -> &mut Self::SignProvider {
+        &mut self.empty
     }
 }
 

--- a/embedded-cal/src/empty.rs
+++ b/embedded-cal/src/empty.rs
@@ -20,6 +20,7 @@ impl<const PLUMBING: bool> Cal for EmptyCal<PLUMBING> {
     type AeadProvider = Self;
     type HashProvider = Self;
     type HmacProvider = Self;
+    type SignProvider = Self;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self
@@ -34,6 +35,10 @@ impl<const PLUMBING: bool> Cal for EmptyCal<PLUMBING> {
     }
 
     fn hmac(&mut self) -> &mut Self::HmacProvider {
+        self
+    }
+
+    fn sign(&mut self) -> &mut Self::SignProvider {
         self
     }
 }
@@ -205,6 +210,86 @@ impl plumbing::hash::Sha2Short for EmptyCal<true> {
     }
 }
 
+impl<const PLUMBING: bool> SignProvider for EmptyCal<PLUMBING> {
+    type Algorithm = NoAlgorithms;
+    type Signature = NoAlgorithms;
+    type SecretKey = NoAlgorithms;
+    type PublicKey = NoAlgorithms;
+    type VisibleSecretKey = NoAlgorithms;
+
+    fn generate_visible(&mut self, alg: Self::Algorithm) -> Self::VisibleSecretKey {
+        match alg {}
+    }
+
+    #[allow(unreachable_code, reason = "needed to satisfy RPIT")]
+    fn export_secretkey_bytes<'s>(
+        &mut self,
+        secretkey: &'s Self::VisibleSecretKey,
+    ) -> impl AsRef<[u8]> + use<'s, PLUMBING> {
+        match *secretkey {};
+        &[]
+    }
+
+    fn import_secretkey_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        _secret: &[u8],
+    ) -> Result<Self::VisibleSecretKey, crate::ImportError> {
+        match alg {}
+    }
+
+    #[allow(unreachable_code, reason = "needed to satisfy RPIT")]
+    fn export_publickey_bytes<'p>(
+        &mut self,
+        public: &'p Self::PublicKey,
+    ) -> impl AsRef<[u8]> + use<'p, PLUMBING> {
+        match *public {}
+        &[]
+    }
+
+    fn import_publickey_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        _data: &[u8],
+    ) -> Result<Self::PublicKey, crate::ImportError> {
+        match alg {}
+    }
+
+    fn public_key(&mut self, private: &Self::SecretKey) -> Self::PublicKey {
+        match *private {}
+    }
+
+    #[allow(unreachable_code, reason = "needed to satisfy RPIT")]
+    fn export_signature_bytes<'s>(
+        &mut self,
+        signature: &'s Self::Signature,
+    ) -> impl AsRef<[u8]> + use<'s, PLUMBING> {
+        match *signature {}
+        &[]
+    }
+
+    fn import_signature_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        _data: &[u8],
+    ) -> Result<Self::Signature, crate::ImportError> {
+        match alg {}
+    }
+
+    fn sign(&mut self, private: &Self::SecretKey, _message: &[u8]) -> Self::Signature {
+        match *private {}
+    }
+
+    fn verify(
+        &mut self,
+        public: &Self::PublicKey,
+        _message: &[u8],
+        _signature: &Self::Signature,
+    ) -> Result<(), SignatureInvalid> {
+        match *public {}
+    }
+}
+
 /// Type which an implementation of [`Cal`] can use when it implements no algorithm for a
 /// particular provider.
 ///
@@ -251,6 +336,12 @@ impl AsRef<[u8]> for NoAlgorithms {
 
 impl DhAlgorithm for NoAlgorithms {
     fn output_length(&self) -> usize {
+        match *self {}
+    }
+}
+
+impl SignAlgorithm for NoAlgorithms {
+    fn signature_length(&self) -> usize {
         match *self {}
     }
 }

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -12,6 +12,7 @@ mod hash;
 mod hkdf;
 mod hmac;
 mod rng;
+mod sign;
 // FIXME: Once we start API stability, this should be a dedicated crate.
 pub mod plumbing;
 

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -28,6 +28,7 @@ pub use hash::{HashAlgorithm, HashProvider, test_hash_algorithm_sha256};
 pub use hkdf::{HkdfError, HkdfProvider};
 pub use hmac::{HmacAlgorithm, HmacProvider, test_hmac_algorithm_hmacsha256};
 pub use rng::test_tryrng;
+pub use sign::{SignAlgorithm, SignProvider, SignatureInvalid};
 
 #[allow(
     type_alias_bounds,
@@ -67,6 +68,14 @@ pub mod accessor {
     pub type HmacKeyOf<C: Cal> = <<C as Cal>::HmacProvider as HmacProvider>::Key;
     pub type HmacStateOf<C: Cal> = <<C as Cal>::HmacProvider as HmacProvider>::State;
     pub type HmacOutputOf<C: Cal> = <<C as Cal>::HmacProvider as HmacProvider>::Output;
+
+    pub type SignProviderOf<C: Cal> = <C as Cal>::SignProvider;
+    pub type SignAlgorithmOf<C: Cal> = <<C as Cal>::SignProvider as SignProvider>::Algorithm;
+    pub type SignVisibleSecretKeyOf<C: Cal> =
+        <<C as Cal>::SignProvider as SignProvider>::VisibleSecretKey;
+    pub type SignSignatureOf<C: Cal> = <<C as Cal>::SignProvider as SignProvider>::Signature;
+    pub type SignSecretKeyOf<C: Cal> = <<C as Cal>::SignProvider as SignProvider>::SecretKey;
+    pub type SignPublicKeyOf<C: Cal> = <<C as Cal>::SignProvider as SignProvider>::PublicKey;
 }
 
 /// Cryptographic abstraction provider that encompasses all features abstracted by the
@@ -96,9 +105,11 @@ pub trait Cal {
     type AeadProvider: AeadProvider;
     type HashProvider: HashProvider;
     type HmacProvider: HmacProvider;
+    type SignProvider: SignProvider;
 
     fn dh(&mut self) -> &mut Self::DhProvider;
     fn aead(&mut self) -> &mut Self::AeadProvider;
     fn hash(&mut self) -> &mut Self::HashProvider;
     fn hmac(&mut self) -> &mut Self::HmacProvider;
+    fn sign(&mut self) -> &mut Self::SignProvider;
 }

--- a/embedded-cal/src/sign.rs
+++ b/embedded-cal/src/sign.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+
+/// Digital signature creation and verification
+pub trait SignProvider {
+    type Algorithm: SignAlgorithm;
+
+    /// A secret key that is intended to be exported
+    /// See [`DhProvider::VisibleSecretKey`][super::DhProvider::VisibleSecretKey]
+    /// for the reason of splitting this from [`SecretKey`][Self::SecretKey]
+    type VisibleSecretKey: Sized + Into<Self::SecretKey>;
+    type SecretKey: Sized;
+    type PublicKey: Sized;
+    type Signature: Sized;
+
+    /// Generates a secret key that is intended to be exported / shared (e.g. to be persisted
+    /// across program executions).
+    fn generate_visible(&mut self, alg: Self::Algorithm) -> Self::VisibleSecretKey;
+
+    /// Generates a secret key.
+    fn generate(&mut self, alg: Self::Algorithm) -> Self::SecretKey {
+        self.generate_visible(alg).into()
+    }
+
+    /// Exposes a private key's key data bytes.
+    fn export_secretkey_bytes<'s>(
+        &mut self,
+        secretkey: &'s Self::VisibleSecretKey,
+    ) -> impl AsRef<[u8]> + use<'s, Self>;
+
+    /// Imports a public key in the inverse operation of
+    /// [`.export_secretkey_bytes()`][Self::export_secretkey_bytes()].
+    fn import_secretkey_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        secret: &[u8],
+    ) -> Result<Self::VisibleSecretKey, super::ImportError>;
+
+    /// Exposes a public key's key data bytes.
+    fn export_publickey_bytes<'p>(
+        &mut self,
+        public: &'p Self::PublicKey,
+    ) -> impl AsRef<[u8]> + use<'p, Self>;
+
+    /// Imports a public key in the inverse operation of
+    /// [`.export_publickey_bytes()`][Self::export_publickey_bytes()].
+    fn import_publickey_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        data: &[u8],
+    ) -> Result<Self::PublicKey, super::ImportError>;
+
+    /// Produces the public key corresponding to a private key.
+    fn public_key(&mut self, private: &Self::SecretKey) -> Self::PublicKey;
+
+    /// Exposes a signature's bytes.
+    ///
+    /// For ECDSA, this is the raw `r || s` representation.
+    fn export_signature_bytes<'s>(
+        &mut self,
+        signature: &'s Self::Signature,
+    ) -> impl AsRef<[u8]> + use<'s, Self>;
+    /// Inverse operation of [`.export_signature_bytes()`][Self::export_signature_bytes()].
+    fn import_signature_bytes(
+        &mut self,
+        alg: Self::Algorithm,
+        data: &[u8],
+    ) -> Result<Self::Signature, super::ImportError>;
+
+    fn sign(&mut self, private: &Self::SecretKey, message: &[u8]) -> Self::Signature;
+
+    fn verify(
+        &mut self,
+        public: &Self::PublicKey,
+        message: &[u8],
+        signature: &Self::Signature,
+    ) -> Result<(), SignatureInvalid>;
+}
+
+/// Error indicating that a signature did not verify against the given public key and message.
+#[derive(Debug)]
+pub struct SignatureInvalid;
+
+impl core::fmt::Display for SignatureInvalid {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("signature is not valid for the given public key and message")
+    }
+}
+
+impl core::error::Error for SignatureInvalid {}
+
+/// A signature algorithm.
+pub trait SignAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
+    /// Length of signatures produced by keys of this algorithm.
+    fn signature_length(&self) -> usize;
+
+    /// Selects a signature algorithm from its COSE "alg" number.
+    ///
+    /// The algorithm number comes from the ["COSE Algorithms"
+    /// registry](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) maintained by IANA.
+    fn from_cose_number(alg: impl Into<i128>) -> Option<Self>;
+}

--- a/embedded-cal/src/sign.rs
+++ b/embedded-cal/src/sign.rs
@@ -98,5 +98,7 @@ pub trait SignAlgorithm: Sized + PartialEq + Eq + core::fmt::Debug + Clone {
     ///
     /// The algorithm number comes from the ["COSE Algorithms"
     /// registry](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) maintained by IANA.
-    fn from_cose_number(alg: impl Into<i128>) -> Option<Self>;
+    fn from_cose_number(_alg: impl Into<i128>) -> Option<Self> {
+        None
+    }
 }

--- a/helpers/ALGORITHMS.cache/enum-algorithm-items
+++ b/helpers/ALGORITHMS.cache/enum-algorithm-items
@@ -34,6 +34,10 @@
     Sha256,
 ./embedded-cal-rustcrypto/src/hash.rs
     Direct(BA),
+./embedded-cal-rustcrypto/src/sign.rs
+    EcdsaP256,
+./embedded-cal-rustcrypto/src/sign.rs
+    Direct(BA),
 ./embedded-cal-software-demo/src/hash.rs
     // FIXME: Ideally we'd employ some witness type of <EC::Base as Sha2Short>::SUPPORTED
 ./embedded-cal-software-demo/src/hash.rs

--- a/helpers/ALGORITHMS.cache/providers
+++ b/helpers/ALGORITHMS.cache/providers
@@ -5,6 +5,7 @@
 ./embedded-cal-rustcrypto/src/aead.rs:impl<Base: Cal> AeadProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-rustcrypto/src/dh.rs:impl<Base: Cal> DhProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-rustcrypto/src/hash.rs:impl<Base: Cal> HashProvider for RustcryptoCalExtender<Base> {
+./embedded-cal-rustcrypto/src/sign.rs:impl<Base: Cal> SignProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-software-demo/src/hash.rs:impl<EC: ExtenderConfig> HashProvider for Extender<EC> {
 ./embedded-cal-software-demo/src/hmac.rs:impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
 ./embedded-cal-stm32wba55/src/aead.rs:impl embedded_cal::AeadProvider for super::Stm32wba55Cal {
@@ -14,6 +15,7 @@
 ./embedded-cal/src/empty.rs:impl<const PLUMBING: bool> HmacProvider for EmptyCal<PLUMBING> {
 ./embedded-cal/src/empty.rs:impl<const PLUMBING: bool> AeadProvider for EmptyCal<PLUMBING> {
 ./embedded-cal/src/empty.rs:impl<const PLUMBING: bool> DhProvider for EmptyCal<PLUMBING> {
+./embedded-cal/src/empty.rs:impl<const PLUMBING: bool> SignProvider for EmptyCal<PLUMBING> {
 ./embedded-cal/src/hkdf.rs:impl<H: HmacProvider> HkdfProvider for H {
 ./testvectors/src/aead.rs:pub fn test_aead_aesccm_16_64_128(cal: &mut impl embedded_cal::AeadProvider) {
 ./testvectors/src/aead.rs:pub fn test_aead_aesccm_16_64_256(cal: &mut impl embedded_cal::AeadProvider) {

--- a/testvectors/src/lib.rs
+++ b/testvectors/src/lib.rs
@@ -6,6 +6,7 @@ use hexlit::hex;
 
 pub mod aead;
 pub mod dh;
+pub mod sign;
 
 pub use aead::{
     test_aead_aesccm_16_64_128, test_aead_aesccm_16_64_256, test_aead_aesgcm_128,

--- a/testvectors/src/sign.rs
+++ b/testvectors/src/sign.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+
+use hexlit::hex;
+
+pub struct SignVector {
+    cose_alg: i16,
+    private_key: &'static [u8],
+    public_key: &'static [u8],
+    message: &'static [u8],
+    r: &'static [u8],
+    s: &'static [u8],
+}
+
+impl SignVector {
+    pub fn test_with<C: embedded_cal::Cal>(&self, cal: &mut C) {
+        use embedded_cal::{SignAlgorithm, SignProvider};
+
+        let cal = cal.sign();
+
+        let alg = <C::SignProvider as SignProvider>::Algorithm::from_cose_number(self.cose_alg)
+            .expect("algorithm not supported by CAL");
+
+        let private = cal
+            .import_secretkey_bytes(alg.clone(), self.private_key)
+            .expect("failed to load private key")
+            .into();
+        let public = cal.public_key(&private);
+
+        assert_eq!(
+            cal.export_publickey_bytes(&public).as_ref(),
+            self.public_key,
+            "public key not derived as expected"
+        );
+
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..32].copy_from_slice(self.r);
+        sig_bytes[32..].copy_from_slice(self.s);
+        let signature = cal
+            .import_signature_bytes(alg, &sig_bytes)
+            .expect("failed to load known-answer signature");
+
+        cal.verify(&public, self.message, &signature)
+            .expect("known-answer signature did not verify");
+    }
+}
+
+pub const ECDSA_P256: &[SignVector] = &[
+    SignVector {
+        cose_alg: -7,
+        private_key: &hex!("0c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f672"),
+        public_key: &hex!("439ed13599d6e4f6ce33118b0421d0630e57c6919f6e0a8068c3c85a0c2412bf"),
+        message: b"sample",
+        r: &hex!("951d683e4af187dc4bf4a91853399fc082c078782ee190032a476cf0ae62bfcd"),
+        s: &hex!("fd24f7278499ae4649070ffca0eecbbb745c9162f15cc129ffff6a76f5dd0a58"),
+    },
+    SignVector {
+        cose_alg: -7,
+        private_key: &hex!("0519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b18"),
+        public_key: &hex!("03f5de2249cd1bd00347244cd6399ac88e514f6267ef2ea44c7fe061cdfd5b76"),
+        message: b"This is a longer test message used to exercise multi-block SHA-256 hashing inside the ECDSA test vector generation.",
+        r: &hex!("852d93e4833a0f923256beee6d12e6919f741517f8f6b895f1b0d27d70a4d31a"),
+        s: &hex!("1b178851c2c51d667b1827e682251a6f4a8391e01012fa103ceb103c46f594a7"),
+    },
+    SignVector {
+        cose_alg: -7,
+        private_key: &hex!("7a1e8f2c3b9d4a5e6f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e7"),
+        public_key: &hex!("3c976244c661396bf73775d98f90850931a8742d1a4442dfe0ee14fe0c592b8a"),
+        message: b"another test vector for embedded-cal ECDSA coverage",
+        r: &hex!("23480a65e2b1a5b44db30ee256b83c32ac1db8977fcfcf50d79ca87e7f1bd3e4"),
+        s: &hex!("b3e9dfff4d365d454ccc639e844a243a4c3bbc41ad0d1a64f5ac95f5d26acdd7"),
+    },
+];


### PR DESCRIPTION
This PR proposes an `SignProvider` that should be used for both ECDSA/EdDSA.

Also give a implementation working using RustCrypto. Its heavily based on the `DhProvider`, but maybe its too much having `Algorithm + Signature + SecretKey + PublicKey + VisibleSecretKey` as associated types?