### PR TITLE
software-demo/hkdf: Use full type's SHA256 rather than unconditionally using own

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -47,9 +47,12 @@ Limitation in AAD streaming or message size are subject to ongoing work.
 |-----------|----------------|-------|
 | HMAC w/ SHA-256 | rustcrypto | |
 | HMAC w/ SHA-256 | software-demo | |
+| HMAC w/ SHA-256 | stm32wba55 | |
 
 # HKDF
 
 | Algorithm | Implementation | Notes |
 |-----------|----------------|-------|
-| HKDF on HMAC w/ SHA-256 | blanket | to be moved into implementations |
+| HKDF on HMAC w/ SHA-256 | rustcrypto | |
+| HKDF on HMAC w/ SHA-256 | software-demo | |
+| HKDF on HMAC w/ SHA-256 | stm32wba55 | |

--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -53,6 +53,6 @@ Limitation in AAD streaming or message size are subject to ongoing work.
 
 | Algorithm | Implementation | Notes |
 |-----------|----------------|-------|
-| HKDF on HMAC w/ SHA-256 | rustcrypto | |
-| HKDF on HMAC w/ SHA-256 | software-demo | |
+| HKDF on HMAC w/ SHA-256 | rustcrypto | **not** using any SHA-256 acceleration |
+| HKDF on HMAC w/ SHA-256 | software-demo | **not** using any SHA-256 acceleration|
 | HKDF on HMAC w/ SHA-256 | stm32wba55 | |

--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -54,5 +54,5 @@ Limitation in AAD streaming or message size are subject to ongoing work.
 | Algorithm | Implementation | Notes |
 |-----------|----------------|-------|
 | HKDF on HMAC w/ SHA-256 | rustcrypto | **not** using any SHA-256 acceleration |
-| HKDF on HMAC w/ SHA-256 | software-demo | **not** using any SHA-256 acceleration|
+| HKDF on HMAC w/ SHA-256 | software-demo | |
 | HKDF on HMAC w/ SHA-256 | stm32wba55 | |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "embedded-cal",
  "getrandom 0.4.2",
  "heapless",
+ "hmac",
  "p256",
  "rand_core 0.10.1",
  "rand_core 0.6.4",

--- a/embedded-cal-rustcrypto/Cargo.toml
+++ b/embedded-cal-rustcrypto/Cargo.toml
@@ -17,6 +17,7 @@ ccm = { version = "0.5.0", default-features = false }
 digest = "0.10.7"
 embedded-cal.path = "../embedded-cal"
 heapless = { version = "0.9.3", features = ["zeroize"] }
+hmac = { version = "0.12.1", default-features = false }
 p256 = { version = "0.13.2", default-features = false, features = ["ecdh"] }
 sha2 = { version = "0.10.9", default-features = false }
 testvectors.path = "../testvectors"

--- a/embedded-cal-rustcrypto/src/hmac.rs
+++ b/embedded-cal-rustcrypto/src/hmac.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+
+use super::*;
+use ::hmac::Mac;
+use embedded_cal::{Cal, HmacProvider};
+
+type HmacSha256 = ::hmac::Hmac<sha2::Sha256>;
+
+// std only macro-generates `Default` for arrays up to 32 elements
+type MaxLenBuf = digest::generic_array::GenericArray<u8, digest::consts::U64>;
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum HmacAlgorithm<BA> {
+    HmacSha256,
+    Direct(BA),
+}
+
+impl<BA: embedded_cal::HmacAlgorithm> embedded_cal::HmacAlgorithm for HmacAlgorithm<BA> {
+    // FIXME: computing a max(32, BA::MAX_LEN) here would need a generic const expression
+    // which is not available on stable Rust.
+    const MAX_LEN: usize = 64;
+
+    type MaxLenBuf = MaxLenBuf;
+
+    fn len(&self) -> usize {
+        match self {
+            HmacAlgorithm::HmacSha256 => 32,
+            HmacAlgorithm::Direct(a) => a.len(),
+        }
+    }
+
+    #[inline]
+    fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
+        let number: i128 = number.into();
+        if let Some(a) = BA::from_cose_number(number) {
+            return Some(HmacAlgorithm::Direct(a));
+        }
+        match number {
+            5 => Some(HmacAlgorithm::HmacSha256),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum HmacKey<BK> {
+    HmacSha256(HmacSha256),
+    Direct(BK),
+}
+
+pub enum HmacState<BS> {
+    HmacSha256(HmacSha256),
+    Direct(BS),
+}
+
+pub enum HmacResult<BR> {
+    HmacSha256([u8; 32]),
+    Direct(BR),
+}
+
+impl<BR: AsRef<[u8]>> AsRef<[u8]> for HmacResult<BR> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            HmacResult::HmacSha256(r) => &r[..],
+            HmacResult::Direct(r) => r.as_ref(),
+        }
+    }
+}
+
+impl<Base: Cal> HmacProvider for RustcryptoCalExtender<Base> {
+    type Algorithm = HmacAlgorithm<HmacAlgorithmOf<Base>>;
+    type Key = HmacKey<HmacKeyOf<Base>>;
+    type State = HmacState<HmacStateOf<Base>>;
+    type Output = HmacResult<HmacOutputOf<Base>>;
+
+    fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
+        match algorithm {
+            HmacAlgorithm::HmacSha256 => HmacKey::HmacSha256(
+                HmacSha256::new_from_slice(key).expect("HMAC accepts keys of any length"),
+            ),
+            HmacAlgorithm::Direct(a) => HmacKey::Direct(self.base.hmac().load_from_keydata(a, key)),
+        }
+    }
+
+    fn init(&mut self, key: Self::Key) -> Self::State {
+        match key {
+            HmacKey::HmacSha256(h) => HmacState::HmacSha256(h),
+            HmacKey::Direct(k) => HmacState::Direct(self.base.hmac().init(k)),
+        }
+    }
+
+    fn update(&mut self, state: &mut Self::State, data: &[u8]) {
+        match state {
+            HmacState::HmacSha256(h) => h.update(data),
+            HmacState::Direct(s) => self.base.hmac().update(s, data),
+        }
+    }
+
+    fn finalize(&mut self, state: Self::State) -> Self::Output {
+        match state {
+            HmacState::HmacSha256(h) => HmacResult::HmacSha256(h.finalize().into_bytes().into()),
+            HmacState::Direct(s) => HmacResult::Direct(self.base.hmac().finalize(s)),
+        }
+    }
+}

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -133,6 +133,13 @@ mod tests {
     }
 
     #[test]
+    fn test_hkdf_sha256() {
+        let mut cal = RustcryptoCal::new();
+
+        testvectors::test_hkdf_sha256(&mut cal);
+    }
+
+    #[test]
     fn test_aead_aesccm_16_64_128() {
         let mut cal = RustcryptoCal::new();
 

--- a/embedded-cal-rustcrypto/src/lib.rs
+++ b/embedded-cal-rustcrypto/src/lib.rs
@@ -4,6 +4,7 @@
 mod aead;
 mod dh;
 mod hash;
+mod hmac;
 mod rng;
 
 use digest::Digest;
@@ -62,7 +63,7 @@ impl<Base: embedded_cal::Cal> embedded_cal::Cal for RustcryptoCalExtender<Base> 
     type DhProvider = Self;
     type AeadProvider = Self;
     type HashProvider = Self;
-    type HmacProvider = HmacProviderOf<Base>;
+    type HmacProvider = Self;
 
     fn dh(&mut self) -> &mut Self::DhProvider {
         self
@@ -74,7 +75,7 @@ impl<Base: embedded_cal::Cal> embedded_cal::Cal for RustcryptoCalExtender<Base> 
         self
     }
     fn hmac(&mut self) -> &mut Self::HmacProvider {
-        self.base.hmac()
+        self
     }
 }
 
@@ -121,6 +122,14 @@ mod tests {
 
         embedded_cal::test_hash_algorithm_sha256::<HashAlgorithmOf<RustcryptoCal>>();
         testvectors::test_hash_algorithm_sha256(&mut cal);
+    }
+
+    #[test]
+    fn test_hmac_sha256() {
+        let mut cal = RustcryptoCal::new();
+
+        embedded_cal::test_hmac_algorithm_hmacsha256::<HmacAlgorithmOf<RustcryptoCal>>();
+        testvectors::test_hmac_sha256(&mut cal);
     }
 
     #[test]

--- a/embedded-cal-software-demo/src/hmac.rs
+++ b/embedded-cal-software-demo/src/hmac.rs
@@ -2,32 +2,53 @@
 // SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
 
 use embedded_cal::{HashProvider, HmacProvider, plumbing::hash::SHA2SHORT_BLOCK_SIZE};
+use embedded_cal::accessor::HashAlgorithmOf;
 
 use crate::hash::{HashAlgorithm, HashResult};
 
 use super::{Extender, ExtenderConfig};
 
 /// HMAC algorithm identifier for software HMAC over [`Extender`].
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum HmacAlgorithm {
-    HmacSha256,
+#[derive(PartialEq, Eq)]
+pub enum HmacAlgorithm<EC: ExtenderConfig> {
+    HmacSha256(HashAlgorithmOf<EC::Base>),
 }
 
-impl embedded_cal::HmacAlgorithm for HmacAlgorithm {
+// Sadly, none of those can be derived because minimal derives don't work
+
+impl<EC: ExtenderConfig> Clone for HmacAlgorithm<EC> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::HmacSha256(sha256) => Self::HmacSha256(sha256.clone()),
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> core::fmt::Debug for HmacAlgorithm<EC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::HmacSha256(sha256) => f.debug_tuple("HmacSha256").field(sha256).finish(),
+        }
+    }
+}
+
+impl<EC: ExtenderConfig> embedded_cal::HmacAlgorithm for HmacAlgorithm<EC> {
     const MAX_LEN: usize = 32;
 
     type MaxLenBuf = [u8; 32];
 
     fn len(&self) -> usize {
         match self {
-            HmacAlgorithm::HmacSha256 => 32,
+            // FIXME: If we generalize here, can use info from inner
+            HmacAlgorithm::HmacSha256(_) => 32,
         }
     }
 
     #[inline]
     fn from_cose_number(number: impl Into<i128>) -> Option<Self> {
-        match number.into() {
-            5 => Some(HmacAlgorithm::HmacSha256),
+        let sha256 = HashAlgorithmOf::<Self>::from_cose_number(-16);
+        match (number.into(), sha256) {
+            (5, Some(sha256)) => Some(HmacAlgorithm::HmacSha256(sha256)),
             _ => None,
         }
     }
@@ -78,19 +99,21 @@ impl AsRef<[u8]> for HmacResult {
 }
 
 impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
-    type Algorithm = HmacAlgorithm;
+    type Algorithm = HmacAlgorithm<EC>;
     type Key = HmacKey<EC>;
     type State = HmacState<EC>;
     type Output = HmacResult;
 
     fn load_from_keydata(&mut self, algorithm: Self::Algorithm, key: &[u8]) -> Self::Key {
+        use embedded_cal::HashAlgorithm;
+
         match algorithm {
-            HmacAlgorithm::HmacSha256 => {
+            HmacAlgorithm::HmacSha256(alg) => {
                 // Normalise key to exactly SHA2SHORT_BLOCK_SIZE bytes.
                 // If key is longer than the block size, hash it first (RFC 2104).
                 let mut key_block = [0u8; SHA2SHORT_BLOCK_SIZE];
                 if key.len() > SHA2SHORT_BLOCK_SIZE {
-                    let hashed = HashProvider::hash(self, HashAlgorithm::Sha256, key);
+                    let hashed = HashProvider::hash(self, alg, key);
                     let h = hashed.as_ref();
                     debug_assert_eq!(h.len(), 32, "SHA-256 must produce 32 bytes");
                     key_block[..h.len()].copy_from_slice(h);
@@ -111,7 +134,7 @@ impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
                 }
 
                 // Start inner hash: H((key XOR ipad) || ...)
-                let mut inner = HashProvider::init(self, HashAlgorithm::Sha256);
+                let mut inner = HashProvider::init(self, alg);
                 HashProvider::update(self, &mut inner, &ipad_block);
 
                 HmacKey::HmacSha256 { inner, outer_key }

--- a/helpers/ALGORITHMS.cache/enum-algorithm-items
+++ b/helpers/ALGORITHMS.cache/enum-algorithm-items
@@ -34,6 +34,10 @@
     Sha256,
 ./embedded-cal-rustcrypto/src/hash.rs
     Direct(BA),
+./embedded-cal-rustcrypto/src/hmac.rs
+    HmacSha256,
+./embedded-cal-rustcrypto/src/hmac.rs
+    Direct(BA),
 ./embedded-cal-software-demo/src/hash.rs
     // FIXME: Ideally we'd employ some witness type of <EC::Base as Sha2Short>::SUPPORTED
 ./embedded-cal-software-demo/src/hash.rs

--- a/helpers/ALGORITHMS.cache/providers
+++ b/helpers/ALGORITHMS.cache/providers
@@ -5,6 +5,7 @@
 ./embedded-cal-rustcrypto/src/aead.rs:impl<Base: Cal> AeadProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-rustcrypto/src/dh.rs:impl<Base: Cal> DhProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-rustcrypto/src/hash.rs:impl<Base: Cal> HashProvider for RustcryptoCalExtender<Base> {
+./embedded-cal-rustcrypto/src/hmac.rs:impl<Base: Cal> HmacProvider for RustcryptoCalExtender<Base> {
 ./embedded-cal-software-demo/src/hash.rs:impl<EC: ExtenderConfig> HashProvider for Extender<EC> {
 ./embedded-cal-software-demo/src/hmac.rs:impl<EC: ExtenderConfig> HmacProvider for Extender<EC> {
 ./embedded-cal-stm32wba55/src/aead.rs:impl embedded_cal::AeadProvider for super::Stm32wba55Cal {


### PR DESCRIPTION
Previously, this would always use the software-demo's SHA-256; implementation (which would then maybe go to the hardware). But when the underlying type has an own full SHA-256 (eg. because the hardware supports the full high-level interface), that should be used. Going through Self's hash algorithm ensures that whichever implementation gets selected when just doing SHA also gets selected here.

---

This builds on #102; only the last commit is what this PR is about.

I didn't test this again after finding the code sitting on my disk for too long, hence the draft status.