### PR TITLE
add tests to test Ec trait directly

### DIFF
--- a/embedded-cal-nrf54l15/src/dh.rs
+++ b/embedded-cal-nrf54l15/src/dh.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
 
+use embedded_cal::montgomery::{clamp_x448, clamp_x25519, mask_u_x25519};
 use embedded_cal::p256::{
     P256_GX_BYTES, P256_GY_BYTES, P256_ORDER, bytes_to_words, ge, p256_recover_y,
 };
@@ -115,16 +116,6 @@ const X448_COEFF_A: [u8; 56] = [
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
-
-fn clamp_x25519(k: &mut [u8; 32]) {
-    k[0] &= 0xF8;
-    k[31] = (k[31] | 0x40) & 0x7F;
-}
-
-fn clamp_x448(k: &mut [u8; 56]) {
-    k[0] &= 0xFC;
-    k[55] |= 0x80;
-}
 
 #[derive(PartialEq, Eq, Debug, Clone, Zeroize)]
 pub enum DhAlgorithm {
@@ -484,7 +475,7 @@ impl embedded_cal::DhProvider for super::Nrf54l15Cal {
             }
             DhAlgorithm::X25519 => {
                 let mut x: [u8; _] = data.try_into().map_err(|_| embedded_cal::ImportError)?;
-                x[31] &= 0x7F;
+                mask_u_x25519(&mut x);
                 Ok(PublicKey::X25519(
                     self.x25519().point(x.into(), [0; _].into()),
                 ))

--- a/embedded-cal-nrf54l15/tests/integration.rs
+++ b/embedded-cal-nrf54l15/tests/integration.rs
@@ -89,4 +89,25 @@ mod tests {
             v.test_with(state.cal.dh());
         }
     }
+
+    #[test]
+    fn test_ec_plumbing_p256(state: &mut super::TestState) {
+        for v in testvectors::dh::RFC5903_P256 {
+            v.test_plumbing_p256(&mut state.cal);
+        }
+    }
+
+    #[test]
+    fn test_ec_plumbing_x25519(state: &mut super::TestState) {
+        for v in testvectors::dh::RFC7748_X25519 {
+            v.test_plumbing_x25519(&mut state.cal);
+        }
+    }
+
+    #[test]
+    fn test_ec_plumbing_x448(state: &mut super::TestState) {
+        for v in testvectors::dh::RFC7748_X448 {
+            v.test_plumbing_x448(&mut state.cal);
+        }
+    }
 }

--- a/embedded-cal-software-demo/src/lib.rs
+++ b/embedded-cal-software-demo/src/lib.rs
@@ -51,6 +51,27 @@ impl<EC: ExtenderConfig> embedded_cal::Cal for Extender<EC> {
     }
 }
 
+impl<EC: ExtenderConfig> embedded_cal::plumbing::ec::Ec for Extender<EC> {
+    const MAX_SCALAR_LENGTH: usize =
+        <EC::Base as embedded_cal::plumbing::ec::Ec>::MAX_SCALAR_LENGTH;
+
+    type PrimitivesP256 = <EC::Base as embedded_cal::plumbing::ec::Ec>::PrimitivesP256;
+    type PrimitivesX25519 = <EC::Base as embedded_cal::plumbing::ec::Ec>::PrimitivesX25519;
+    type PrimitivesX448 = <EC::Base as embedded_cal::plumbing::ec::Ec>::PrimitivesX448;
+
+    fn p256(&mut self) -> &mut Self::PrimitivesP256 {
+        self.0.p256()
+    }
+
+    fn x25519(&mut self) -> &mut Self::PrimitivesX25519 {
+        self.0.x25519()
+    }
+
+    fn x448(&mut self) -> &mut Self::PrimitivesX448 {
+        self.0.x448()
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     pub(crate) mod dummy_sha256;

--- a/embedded-cal-stm32wba55/tests/integration.rs
+++ b/embedded-cal-stm32wba55/tests/integration.rs
@@ -80,4 +80,11 @@ mod tests {
             v.test_with(state.cal.dh());
         }
     }
+
+    #[test]
+    fn test_ec_plumbing_p256(state: &mut super::TestState) {
+        for v in testvectors::dh::RFC5903_P256 {
+            v.test_plumbing_p256(&mut state.cal);
+        }
+    }
 }

--- a/embedded-cal/src/lib.rs
+++ b/embedded-cal/src/lib.rs
@@ -3,6 +3,7 @@
 #![no_std]
 
 pub mod empty;
+pub mod montgomery;
 pub mod p256;
 pub mod util;
 

--- a/embedded-cal/src/montgomery.rs
+++ b/embedded-cal/src/montgomery.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
+
+//! Scalar and coordinate fixups for the RFC 7748 curves (X25519 and X448).
+//!
+//! The [EC plumbing][crate::plumbing::ec::EcPrimitives] deliberately does not clamp its operands,
+//! so callers that feed it RFC 7748 key material have to apply these themselves. They live here
+//! rather than in a back-end because every user of the plumbing layer needs the same ones.
+
+/// Applies the `decodeScalar25519` fixups of [RFC 7748 section 5] to a private key.
+pub fn clamp_x25519(k: &mut [u8; 32]) {
+    k[0] &= 0xF8;
+    k[31] = (k[31] | 0x40) & 0x7F;
+}
+
+/// Applies the `decodeScalar448` fixups of [RFC 7748 section 5] to a private key.
+pub fn clamp_x448(k: &mut [u8; 56]) {
+    k[0] &= 0xFC;
+    k[55] |= 0x80;
+}
+
+/// Clears the unused most significant bit of an X25519 u-coordinate.
+///
+/// [RFC 7748 section 5] mandates this when decoding a u-coordinate; it has no X448 counterpart
+/// because that curve's field elements fill their 56 bytes exactly.
+pub fn mask_u_x25519(u: &mut [u8; 32]) {
+    u[31] &= 0x7F;
+}

--- a/testvectors/src/dh.rs
+++ b/testvectors/src/dh.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: Inria-AIO, Cryspen, and Christian Amsüss
 
+use embedded_cal::plumbing::ec::{Curve, Ec, EcPrimitives, P256, X448, X25519};
 use hexlit::hex;
 
 pub struct EccVector {
@@ -106,3 +107,228 @@ pub const RFC5903_P256: &[EccVector] = &[EccVector {
     bob_public: &hex!("D12DFB52 89C8D4F8 1208B702 70398C34 2296970A 0BCCB74C 736FC755 4494BF63"),
     shared_secret: &hex!("D6840F6B 42F6EDAF D13116E0 E1256520 2FEF8E9E CE7DCE03 812464D0 4B9442DE"),
 }];
+
+/// Base point u-coordinate of X25519 (RFC 7748 section 4.1), little-endian.
+const X25519_BASE_U: [u8; 32] = {
+    let mut u = [0; 32];
+    u[0] = 9;
+    u
+};
+
+/// Base point u-coordinate of X448 (RFC 7748 section 4.2), little-endian.
+const X448_BASE_U: [u8; 56] = {
+    let mut u = [0; 56];
+    u[0] = 5;
+    u
+};
+
+/// Tests that exercise the [EC plumbing][embedded_cal::plumbing::ec] directly
+impl EccVector {
+    pub fn test_plumbing_p256<E: Ec>(&self, ec: &mut E) {
+        assert_eq!(self.ecdh_curve, 1, "vector is not a P-256 vector");
+        const {
+            assert!(
+                <E::PrimitivesP256 as EcPrimitives<P256>>::HAS_MULTIPLY_SCALAR_POINT,
+                "back-end does not implement P-256 scalar multiplication"
+            )
+        };
+        let p256 = ec.p256();
+
+        for (private, public) in [
+            (self.alice_private, self.alice_public),
+            (self.bob_private, self.bob_public),
+        ] {
+            // Scalar import/export round trip, independent of any multiplication
+            let d = p256
+                .import_scalar_bytes(private)
+                .expect("test vector scalar rejected");
+            assert_eq!(
+                p256.export_scalar_bytes(&d).as_ref(),
+                private,
+                "P-256 scalar did not survive an import/export round trip"
+            );
+
+            // d * G == the public key. Both generator coordinates are known constants, so this
+            // needs no point decompression.
+            let base = base_point_p256(p256);
+            let computed = p256.multiply_scalar_point(&d, &base);
+            let computed_x = p256.x_coord(&computed);
+            assert_eq!(
+                p256.export_scalar_bytes(&computed_x).as_ref(),
+                public,
+                "P-256 public key does not match the test vector"
+            );
+        }
+
+        // d_alice * Q_bob == Z == d_bob * Q_alice.
+        for (private, peer) in [
+            (self.alice_private, self.bob_public),
+            (self.bob_private, self.alice_public),
+        ] {
+            let d = p256
+                .import_scalar_bytes(private)
+                .expect("test vector scalar rejected");
+            let peer = point_from_compact_p256(p256, peer);
+            let shared = p256.multiply_scalar_point(&d, &peer);
+            let shared_x = p256.x_coord(&shared);
+            assert_eq!(
+                p256.export_scalar_bytes(&shared_x).as_ref(),
+                self.shared_secret,
+                "P-256 shared secret does not match the test vector"
+            );
+        }
+    }
+
+    pub fn test_plumbing_x25519<E: Ec>(&self, ec: &mut E) {
+        assert_eq!(self.ecdh_curve, 4, "vector is not an X25519 vector");
+        const {
+            assert!(
+                <E::PrimitivesX25519 as EcPrimitives<X25519>>::HAS_MULTIPLY_SCALAR_POINT,
+                "back-end does not implement X25519 scalar multiplication"
+            )
+        };
+        let x25519 = ec.x25519();
+
+        for (private, public) in [
+            (self.alice_private, self.alice_public),
+            (self.bob_private, self.bob_public),
+        ] {
+            let mut scalar: [u8; 32] = private.try_into().expect("vector has a 32 byte scalar");
+            embedded_cal::montgomery::clamp_x25519(&mut scalar);
+            let d = x25519
+                .import_scalar_bytes(&scalar)
+                .expect("test vector scalar rejected");
+            assert_eq!(
+                x25519.export_scalar_bytes(&d).as_ref(),
+                scalar,
+                "X25519 scalar did not survive an import/export round trip"
+            );
+
+            let base = montgomery_point(x25519, &X25519_BASE_U);
+            let computed = x25519.multiply_scalar_point(&d, &base);
+            let computed_u = x25519.x_coord(&computed);
+            assert_eq!(
+                x25519.export_scalar_bytes(&computed_u).as_ref(),
+                public,
+                "X25519 public key does not match the test vector"
+            );
+        }
+
+        for (private, peer) in [
+            (self.alice_private, self.bob_public),
+            (self.bob_private, self.alice_public),
+        ] {
+            let mut scalar: [u8; 32] = private.try_into().expect("vector has a 32 byte scalar");
+            embedded_cal::montgomery::clamp_x25519(&mut scalar);
+            let d = x25519
+                .import_scalar_bytes(&scalar)
+                .expect("test vector scalar rejected");
+
+            let mut peer_u: [u8; 32] = peer.try_into().expect("vector has a 32 byte u coordinate");
+            embedded_cal::montgomery::mask_u_x25519(&mut peer_u);
+            let peer = montgomery_point(x25519, &peer_u);
+
+            let shared = x25519.multiply_scalar_point(&d, &peer);
+            let shared_u = x25519.x_coord(&shared);
+            assert_eq!(
+                x25519.export_scalar_bytes(&shared_u).as_ref(),
+                self.shared_secret,
+                "X25519 shared secret does not match the test vector"
+            );
+        }
+    }
+
+    pub fn test_plumbing_x448<E: Ec>(&self, ec: &mut E) {
+        assert_eq!(self.ecdh_curve, 5, "vector is not an X448 vector");
+        const {
+            assert!(
+                <E::PrimitivesX448 as EcPrimitives<X448>>::HAS_MULTIPLY_SCALAR_POINT,
+                "back-end does not implement X448 scalar multiplication"
+            )
+        };
+        let x448 = ec.x448();
+
+        for (private, public) in [
+            (self.alice_private, self.alice_public),
+            (self.bob_private, self.bob_public),
+        ] {
+            let mut scalar: [u8; 56] = private.try_into().expect("vector has a 56 byte scalar");
+            embedded_cal::montgomery::clamp_x448(&mut scalar);
+            let d = x448
+                .import_scalar_bytes(&scalar)
+                .expect("test vector scalar rejected");
+            assert_eq!(
+                x448.export_scalar_bytes(&d).as_ref(),
+                scalar,
+                "X448 scalar did not survive an import/export round trip"
+            );
+
+            let base = montgomery_point(x448, &X448_BASE_U);
+            let computed = x448.multiply_scalar_point(&d, &base);
+            let computed_u = x448.x_coord(&computed);
+            assert_eq!(
+                x448.export_scalar_bytes(&computed_u).as_ref(),
+                public,
+                "X448 public key does not match the test vector"
+            );
+        }
+
+        for (private, peer) in [
+            (self.alice_private, self.bob_public),
+            (self.bob_private, self.alice_public),
+        ] {
+            let mut scalar: [u8; 56] = private.try_into().expect("vector has a 56 byte scalar");
+            embedded_cal::montgomery::clamp_x448(&mut scalar);
+            let d = x448
+                .import_scalar_bytes(&scalar)
+                .expect("test vector scalar rejected");
+            let peer = montgomery_point(x448, peer);
+
+            let shared = x448.multiply_scalar_point(&d, &peer);
+            let shared_u = x448.x_coord(&shared);
+            assert_eq!(
+                x448.export_scalar_bytes(&shared_u).as_ref(),
+                self.shared_secret,
+                "X448 shared secret does not match the test vector"
+            );
+        }
+    }
+}
+
+/// Builds the P-256 generator as a plumbing point.
+fn base_point_p256<P: EcPrimitives<P256>>(p256: &mut P) -> P::Point {
+    let x = p256
+        .import_scalar_bytes(&embedded_cal::p256::P256_GX_BYTES)
+        .expect("generator x is a valid scalar");
+    let y = p256
+        .import_scalar_bytes(&embedded_cal::p256::P256_GY_BYTES)
+        .expect("generator y is a valid scalar");
+    p256.point(x, y)
+}
+
+/// Builds a P-256 point from its compact (x-only) representation.
+fn point_from_compact_p256<P: EcPrimitives<P256>>(p256: &mut P, x: &[u8]) -> P::Point {
+    let x: &[u8; 32] = x.try_into().expect("vector has a 32 byte x coordinate");
+    let y = embedded_cal::p256::p256_recover_y(x).expect("vector point is on the curve");
+    let x = p256
+        .import_scalar_bytes(x)
+        .expect("test vector coordinate rejected");
+    let y = p256
+        .import_scalar_bytes(&y)
+        .expect("recovered coordinate rejected");
+    p256.point(x, y)
+}
+
+/// Builds a Montgomery curve point from its u coordinate.
+///
+/// The `y` coordinate is unused on these curves (see [`EcPrimitives::point()`]), but the interface
+/// demands one, so a zero scalar is passed.
+fn montgomery_point<C: Curve, P: EcPrimitives<C>>(primitives: &mut P, u: &[u8]) -> P::Point {
+    let unused_y = primitives
+        .import_scalar_bytes(&[0; 56][..u.len()])
+        .expect("zero is a valid scalar");
+    let u = primitives
+        .import_scalar_bytes(u)
+        .expect("test vector u coordinate rejected");
+    primitives.point(u, unused_y)
+}


### PR DESCRIPTION
Today the trait is tested using the DhProvider, but whentestsing hardware it is just easier having the test directly on EC. 